### PR TITLE
[JENKINS-60014] Add the time of a commit to the blame.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>io.jenkins.plugins</groupId>
   <packaging>hpi</packaging>
   <name>Forensics API Plugin</name>
-  <version>0.5.1-SNAPSHOT</version>
+  <version>0.6.0-SNAPSHOT</version>
   <description>Jenkins plug-that defines an API to mine and analyze data from a repository.</description>
 
   <properties>

--- a/src/main/java/io/jenkins/plugins/forensics/blame/FileBlame.java
+++ b/src/main/java/io/jenkins/plugins/forensics/blame/FileBlame.java
@@ -12,8 +12,8 @@ import org.apache.commons.lang3.StringUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Stores the repository blames for several lines of a single file. File names are stored using the absolute path
- * of the file.
+ * Stores the repository blames for several lines of a single file. File names are stored using the absolute path of the
+ * file.
  *
  * @author Ullrich Hafner
  */
@@ -167,7 +167,10 @@ public class FileBlame implements Iterable<Integer>, Serializable {
     }
 
     private int getIntegerValue(final Map<Integer, Integer> map, final int line) {
-        return map.getOrDefault(line, EMPTY_INTEGER);
+        if (map != null && map.containsKey(line)) {
+            return map.get(line);
+        }
+        return EMPTY_INTEGER;
     }
 
     private void setIntegerValue(final Map<Integer, Integer> map, final int lineNumber, final Integer value) {

--- a/src/main/java/io/jenkins/plugins/forensics/blame/FileBlame.java
+++ b/src/main/java/io/jenkins/plugins/forensics/blame/FileBlame.java
@@ -24,6 +24,7 @@ public class FileBlame implements Iterable<Integer>, Serializable {
     private static final String WINDOWS_BACK_SLASH = "\\";
 
     static final String EMPTY = "-";
+    static final int EMPTY_INTEGER = 0;
 
     private final String fileName;
     private final Set<Integer> lines = new HashSet<>();
@@ -31,6 +32,7 @@ public class FileBlame implements Iterable<Integer>, Serializable {
     private final Map<Integer, String> commitByLine = new HashMap<>();
     private final Map<Integer, String> nameByLine = new HashMap<>();
     private final Map<Integer, String> emailByLine = new HashMap<>();
+    private final Map<Integer, Integer> timeByLine = new HashMap<>();
 
     /**
      * Creates a new instance of {@link FileBlame}.
@@ -128,6 +130,30 @@ public class FileBlame implements Iterable<Integer>, Serializable {
         return getStringValue(emailByLine, line);
     }
 
+    /**
+     * Sets the modification time (i.e. the time of the last commit) for the specified line number.
+     *
+     * @param lineNumber
+     *         the line number
+     * @param time
+     *         the time of the commit
+     */
+    public void setTime(final int lineNumber, final int time) {
+        setIntegerValue(timeByLine, lineNumber, time);
+    }
+
+    /**
+     * Returns the modification time (i.e. the time of the last commit) for the specified line.
+     *
+     * @param line
+     *         the affected line
+     *
+     * @return the time of the last commit
+     */
+    public int getTime(final int line) {
+        return getIntegerValue(timeByLine, line);
+    }
+
     private String getStringValue(final Map<Integer, String> map, final int line) {
         if (map.containsKey(line)) {
             return map.get(line);
@@ -137,6 +163,15 @@ public class FileBlame implements Iterable<Integer>, Serializable {
 
     private void setInternedStringValue(final Map<Integer, String> map, final int lineNumber, final String value) {
         map.put(lineNumber, value.intern());
+        lines.add(lineNumber);
+    }
+
+    private int getIntegerValue(final Map<Integer, Integer> map, final int line) {
+        return map.getOrDefault(line, EMPTY_INTEGER);
+    }
+
+    private void setIntegerValue(final Map<Integer, Integer> map, final int lineNumber, final Integer value) {
+        map.put(lineNumber, value);
         lines.add(lineNumber);
     }
 
@@ -157,6 +192,7 @@ public class FileBlame implements Iterable<Integer>, Serializable {
                     setInternedStringValue(commitByLine, otherLine, other.getCommit(otherLine));
                     setInternedStringValue(nameByLine, otherLine, other.getName(otherLine));
                     setInternedStringValue(emailByLine, otherLine, other.getEmail(otherLine));
+                    setIntegerValue(timeByLine, otherLine, other.getTime(otherLine));
                 }
             }
         }
@@ -195,6 +231,9 @@ public class FileBlame implements Iterable<Integer>, Serializable {
         if (!nameByLine.equals(request.nameByLine)) {
             return false;
         }
+        if (!timeByLine.equals(request.timeByLine)) {
+            return false;
+        }
         return emailByLine.equals(request.emailByLine);
     }
 
@@ -205,6 +244,7 @@ public class FileBlame implements Iterable<Integer>, Serializable {
         result = 31 * result + commitByLine.hashCode();
         result = 31 * result + nameByLine.hashCode();
         result = 31 * result + emailByLine.hashCode();
+        result = 31 * result + timeByLine.hashCode();
         return result;
     }
 }

--- a/src/test/java/io/jenkins/plugins/forensics/blame/BlamesTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/blame/BlamesTest.java
@@ -15,9 +15,11 @@ class BlamesTest {
     private static final String COMMIT = "commit";
     private static final String NAME = "name";
     private static final String EMAIL = "email";
+    private static final int TIME = 12_345;
 
     private static final String FILE_NAME = "file.txt";
     private static final String EMPTY = "-";
+    private static final int EMPTY_TIME = 0;
     private static final String ANOTHER_FILE = "other.txt";
 
     @Test
@@ -38,13 +40,13 @@ class BlamesTest {
     void shouldAddBlamesOfSingleFile() {
         Blames blames = new Blames();
 
-        FileBlame fileBlame = createBlame(1, NAME, EMAIL, COMMIT);
+        FileBlame fileBlame = createBlame(1, NAME, EMAIL, COMMIT, TIME);
         blames.add(fileBlame);
 
         assertThatBlamesContainsOneFile(blames);
         assertThat(blames.getBlame(FILE_NAME)).isEqualTo(fileBlame);
 
-        FileBlame other = createBlame(2, NAME, EMAIL, COMMIT);
+        FileBlame other = createBlame(2, NAME, EMAIL, COMMIT, TIME);
         blames.add(other);
 
         assertThatBlamesContainsOneFile(blames);
@@ -52,20 +54,21 @@ class BlamesTest {
         assertThat(blames.getBlame(FILE_NAME)).hasFileName(FILE_NAME);
         assertThat(blames.getBlame(FILE_NAME)).hasLines(1, 2);
 
-        FileBlame duplicate = createBlame(1, EMPTY, EMPTY, EMPTY);
+        FileBlame duplicate = createBlame(1, EMPTY, EMPTY, EMPTY, EMPTY_TIME);
         blames.add(duplicate);
 
         assertThat(blames.size()).isEqualTo(1);
         assertThat(blames.getBlame(FILE_NAME).getName(1)).isEqualTo(NAME);
         assertThat(blames.getBlame(FILE_NAME).getEmail(1)).isEqualTo(EMAIL);
         assertThat(blames.getBlame(FILE_NAME).getCommit(1)).isEqualTo(COMMIT);
+        assertThat(blames.getBlame(FILE_NAME).getTime(1)).isEqualTo(TIME);
     }
 
     @Test
     void shouldConcatenateWorkspacePath() {
         Blames blames = new Blames();
 
-        FileBlame fileBlame = createBlame("file.txt", 1, NAME, EMAIL, COMMIT);
+        FileBlame fileBlame = createBlame("file.txt", 1, NAME, EMAIL, COMMIT, TIME);
         blames.add(fileBlame);
 
         assertThat(blames.size()).isEqualTo(1);
@@ -79,9 +82,9 @@ class BlamesTest {
     void shouldAddBlamesOfTwoFiles() {
         Blames blames = new Blames();
 
-        FileBlame fileBlame = createBlame(FILE_NAME, 1, NAME, EMAIL, COMMIT);
+        FileBlame fileBlame = createBlame(FILE_NAME, 1, NAME, EMAIL, COMMIT, TIME);
         blames.add(fileBlame);
-        FileBlame other = createBlame(ANOTHER_FILE, 2, NAME, EMAIL, COMMIT);
+        FileBlame other = createBlame(ANOTHER_FILE, 2, NAME, EMAIL, COMMIT, TIME);
         blames.add(other);
 
         verifyBlamesOfTwoFiles(blames, fileBlame, other);
@@ -90,11 +93,11 @@ class BlamesTest {
     @Test
     void shouldMergeBlames() {
         Blames blames = new Blames();
-        FileBlame fileBlame = createBlame(FILE_NAME, 1, NAME, EMAIL, COMMIT);
+        FileBlame fileBlame = createBlame(FILE_NAME, 1, NAME, EMAIL, COMMIT, TIME);
         blames.add(fileBlame);
 
         Blames otherBlames = new Blames();
-        FileBlame other = createBlame(ANOTHER_FILE, 2, NAME, EMAIL, COMMIT);
+        FileBlame other = createBlame(ANOTHER_FILE, 2, NAME, EMAIL, COMMIT, TIME);
         otherBlames.add(other);
 
         blames.addAll(otherBlames);
@@ -136,16 +139,18 @@ class BlamesTest {
         assertThat(blames.contains(FILE_NAME)).isTrue();
     }
 
-    private FileBlame createBlame(final int lineNumber, final String name, final String email, final String commit) {
-        return createBlame(FILE_NAME, lineNumber, name, email, commit);
+    private FileBlame createBlame(final int lineNumber, final String name, final String email, final String commit,
+            final int time) {
+        return createBlame(FILE_NAME, lineNumber, name, email, commit, time);
     }
 
     private FileBlame createBlame(final String fileName, final int lineNumber, final String name, final String email,
-            final String commit) {
+            final String commit, final int time) {
         FileBlame fileBlame = new FileBlame(fileName);
         fileBlame.setName(lineNumber, name);
         fileBlame.setCommit(lineNumber, commit);
         fileBlame.setEmail(lineNumber, email);
+        fileBlame.setTime(lineNumber, time);
         return fileBlame;
     }
 }

--- a/src/test/java/io/jenkins/plugins/forensics/blame/FileBlameTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/blame/FileBlameTest.java
@@ -13,6 +13,7 @@ class FileBlameTest {
     private static final String COMMIT = "commit";
     private static final String NAME = "name";
     private static final String EMAIL = "email";
+    private static final int TIME = 12_345;
 
     @Test
     void shouldCreateInstance() {
@@ -35,12 +36,14 @@ class FileBlameTest {
         request.setCommit(lineNumber, COMMIT);
         request.setName(lineNumber, NAME);
         request.setEmail(lineNumber, EMAIL);
+        request.setTime(lineNumber, TIME);
     }
 
     private void verifyDetails(final FileBlame request, final int line) {
         assertThat(request.getCommit(line)).isEqualTo(COMMIT);
         assertThat(request.getName(line)).isEqualTo(NAME);
         assertThat(request.getEmail(line)).isEqualTo(EMAIL);
+        assertThat(request.getTime(line)).isEqualTo(TIME);
     }
 
     @Test
@@ -66,6 +69,7 @@ class FileBlameTest {
         otherLine.setCommit(2, FileBlame.EMPTY);
         otherLine.setName(2, FileBlame.EMPTY);
         otherLine.setEmail(2, FileBlame.EMPTY);
+        otherLine.setTime(2, FileBlame.EMPTY_INTEGER);
         request.merge(otherLine);
         verifyDetails(request, 1);
         verifyDetails(request, 2);
@@ -82,6 +86,7 @@ class FileBlameTest {
         assertThat(request.getCommit(2)).isEqualTo(FileBlame.EMPTY);
         assertThat(request.getEmail(2)).isEqualTo(FileBlame.EMPTY);
         assertThat(request.getName(2)).isEqualTo(FileBlame.EMPTY);
+        assertThat(request.getTime(2)).isEqualTo(FileBlame.EMPTY_INTEGER);
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-60014](https://issues.jenkins-ci.org/browse/JENKINS-60014).

Introduce the time of a commit to the blame. This enables the user to see not only who made a change, but also when the change was made.