### PR TITLE
[JENKINS-60048] Add absolute creation and modification times to statistics API.

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/miner/FileStatistics.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/FileStatistics.java
@@ -94,6 +94,26 @@ public class FileStatistics implements Serializable {
     }
 
     /**
+     * Returns the creation time of this file.
+     *
+     * @return the time of the creation (given as number of seconds since the standard base time known as "the epoch",
+     *         namely January 1, 1970, 00:00:00 GMT.).
+     */
+    public int getCreationTime() {
+        return creationTime;
+    }
+
+    /**
+     * Returns the time of the last modification of this file (i.e. last commit to the file).
+     *
+     * @return the time of the last modification (given as number of seconds since the standard base time known as "the
+     *         epoch", namely January 1, 1970, 00:00:00 GMT.).
+     */
+    public int getLastModificationTime() {
+        return lastModificationTime;
+    }
+
+    /**
      * Returns the age of this file. It is given as the number of days starting from today. If the file has been created
      * today, then 0 is returned.
      *

--- a/src/test/java/io/jenkins/plugins/forensics/miner/FileStatisticsTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/miner/FileStatisticsTest.java
@@ -22,30 +22,40 @@ class FileStatisticsTest {
         assertThat(statistics).hasAgeInDays(0);
         assertThat(statistics).hasLastModifiedInDays(0);
         assertThat(statistics).hasNumberOfAuthors(0);
+        assertThat(statistics).hasLastModificationTime(0);
+        assertThat(statistics).hasCreationTime(0);
 
         statistics.inspectCommit(ONE_DAY * 9, "one");
         assertThat(statistics).hasNumberOfCommits(1);
         assertThat(statistics).hasAgeInDays(1);
         assertThat(statistics).hasLastModifiedInDays(1);
         assertThat(statistics).hasNumberOfAuthors(1);
+        assertThat(statistics).hasLastModificationTime(ONE_DAY * 9);
+        assertThat(statistics).hasCreationTime(ONE_DAY * 9);
 
         statistics.inspectCommit(ONE_DAY * 8, "one");
         assertThat(statistics).hasNumberOfCommits(2);
         assertThat(statistics).hasAgeInDays(2);
         assertThat(statistics).hasLastModifiedInDays(1);
         assertThat(statistics).hasNumberOfAuthors(1);
+        assertThat(statistics).hasLastModificationTime(ONE_DAY * 9);
+        assertThat(statistics).hasCreationTime(ONE_DAY * 8);
 
         statistics.inspectCommit(ONE_DAY * 7, "two");
         assertThat(statistics).hasNumberOfCommits(3);
         assertThat(statistics).hasAgeInDays(3);
         assertThat(statistics).hasLastModifiedInDays(1);
         assertThat(statistics).hasNumberOfAuthors(2);
+        assertThat(statistics).hasLastModificationTime(ONE_DAY * 9);
+        assertThat(statistics).hasCreationTime(ONE_DAY * 7);
 
         statistics.inspectCommit(ONE_DAY * 7, "three");
         assertThat(statistics).hasNumberOfCommits(4);
         assertThat(statistics).hasAgeInDays(3);
         assertThat(statistics).hasLastModifiedInDays(1);
         assertThat(statistics).hasNumberOfAuthors(3);
+        assertThat(statistics).hasLastModificationTime(ONE_DAY * 9);
+        assertThat(statistics).hasCreationTime(ONE_DAY * 7);
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-60048](https://issues.jenkins-ci.org/browse/JENKINS-60048).

This exposes the absolute time of creation and modification of a file in the `FileStatistics`.