### PR TITLE
Add documentation URL (GitHub)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <slf4j.version>1.7.29</slf4j.version>
     <module.name>${project.groupId}.forensics.api</module.name>
+    <url>https://github.com/jenkinsci/forensics-api-plugin</url>
 
     <!-- Library Dependencies Versions -->
     <error-prone.version>2.3.3</error-prone.version>


### PR DESCRIPTION
This should help plugins.jenkins.io display the documentation correctly in https://plugins.jenkins.io/forensics-api

Not using Maven properties because they are currently not expanded properly (https://github.com/jenkins-infra/update-center2/pull/303)