### PR TITLE
Improve logging if miner or BlamerFactory cannot be created

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
@@ -66,7 +66,17 @@ public abstract class BlamerFactory implements ExtensionPoint {
                 .map(directory -> findBlamer(run, directory, listener, logger))
                 .flatMap(OPTIONAL_MAPPER)
                 .findFirst()
-                .orElse(new NullBlamer());
+                .orElseGet(() -> createNullBlamer(logger));
+    }
+
+    private static Blamer createNullBlamer(final FilteredLog logger) {
+        if (findAllExtensions().isEmpty()) {
+            logger.logError("-> No blamer installed yet. You need to install the `git-forensics` plugin to enable blaming for Git.");
+        }
+        else {
+            logger.logError("-> No suitable blamer found.");
+        }
+        return new NullBlamer();
     }
 
     private static Optional<Blamer> findBlamer(final Run<?, ?> run, final FilePath workTree,

--- a/src/main/java/io/jenkins/plugins/forensics/miner/MinerFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/MinerFactory.java
@@ -67,8 +67,20 @@ public abstract class MinerFactory implements ExtensionPoint {
                 .map(directory -> findMiner(run, directory, listener, logger))
                 .flatMap(OPTIONAL_MAPPER)
                 .findFirst()
-                .orElse(new NullMiner());
+                .orElseGet(() -> createNullMiner(logger));
     }
+
+    private static RepositoryMiner createNullMiner(final FilteredLog logger) {
+        if (findAllExtensions().isEmpty()) {
+            logger.logError("-> No miner installed yet. You need to install the `git-forensics` plugin to enable mining of Git repositories.");
+        }
+        else {
+            logger.logError("-> No suitable miner found.");
+        }
+        return new NullMiner();
+    }
+
+
 
     private static Optional<RepositoryMiner> findMiner(final Run<?, ?> run, final FilePath workTree,
             final TaskListener listener, final FilteredLog logger) {


### PR DESCRIPTION
Currently nothing is reported in the console log if the blamer or miner cannot be created. 
Now error messages are logged if the `git-forensics` plugin is not installed or if the logger cannot be created.