### PR TITLE
Add a small wrapper around ReferenceBuild

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceFinder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceFinder.java
@@ -1,0 +1,44 @@
+package io.jenkins.plugins.forensics.reference;
+
+import java.util.Optional;
+
+import edu.hm.hafner.util.FilteredLog;
+
+import hudson.model.Run;
+
+/**
+ * A small wrapper around the {@link ReferenceBuild} action to provide consumers a simple API to obtain a reference
+ * build.
+ *
+ * @author Ullrich Hafner
+ */
+public class ReferenceFinder {
+    /**
+     * Tries to find a reference build using a registered {@link ReferenceBuild} instance.
+     *
+     * @param build
+     *         the current build to get the reference build for
+     * @param log
+     *         a logger
+     *
+     * @return the recorded reference build if available
+     */
+    public Optional<Run<?, ?>> findReference(final Run<?, ?> build, final FilteredLog log) {
+        ReferenceBuild action = build.getAction(ReferenceBuild.class);
+        if (action == null) {
+            log.logInfo("Reference build recorder is not configured");
+        }
+        else {
+            log.logInfo("Obtaining reference build from reference recorder");
+            Optional<Run<?, ?>> referenceBuild = action.getReferenceBuild();
+            if (referenceBuild.isPresent()) {
+                Run<?, ?> reference = referenceBuild.get();
+                log.logInfo("-> found '%s'", reference.getFullDisplayName());
+
+                return Optional.of(reference);
+            }
+            log.logInfo("-> no reference build recorded");
+        }
+        return Optional.empty();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/forensics/reference/ReferenceFinderTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/reference/ReferenceFinderTest.java
@@ -1,0 +1,54 @@
+package io.jenkins.plugins.forensics.reference;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.util.FilteredLog;
+
+import hudson.model.Run;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link ReferenceFinder}.
+ *
+ * @author Ullrich Hafner
+ */
+class ReferenceFinderTest {
+    @Test
+    void shouldNotFindReferenceIfThereIsNoAction() {
+        ReferenceFinder finder = new ReferenceFinder();
+
+        assertThat(finder.findReference(mock(Run.class), createLogger())).isEmpty();
+    }
+
+    @Test
+    void shouldNotFindReferenceIfThereActionWithOutResult() {
+        ReferenceFinder finder = new ReferenceFinder();
+
+        Run<?, ?> build = mock(Run.class);
+        ReferenceBuild reference = mock(ReferenceBuild.class);
+        when(build.getAction(ReferenceBuild.class)).thenReturn(reference);
+        assertThat(finder.findReference(build, createLogger())).isEmpty();
+    }
+
+    @Test
+    void shouldFindReference() {
+        ReferenceFinder finder = new ReferenceFinder();
+
+        Run<?, ?> build = mock(Run.class);
+        ReferenceBuild reference = mock(ReferenceBuild.class);
+        when(build.getAction(ReferenceBuild.class)).thenReturn(reference);
+
+        Run<?, ?> found = mock(Run.class);
+        when(reference.getReferenceBuild()).thenReturn(Optional.of(found));
+
+        assertThat(finder.findReference(build, createLogger())).contains(found);
+    }
+
+    private FilteredLog createLogger() {
+        return new FilteredLog("Error");
+    }
+}


### PR DESCRIPTION
This new cass provides consumers a simple API to obtain a reference build.