### PR TITLE
Use @POST for form field validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <bootstrap4-api.version>4.5.3-1</bootstrap4-api.version>
     <data-tables-api.version>1.10.21-3</data-tables-api.version>
     <echarts-api.version>4.9.0-2</echarts-api.version>
-    <plugin-util-api.version>1.4.0</plugin-util-api.version>
+    <plugin-util-api.version>1.5.0</plugin-util-api.version>
 
   </properties>
 

--- a/src/main/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder.java
@@ -11,6 +11,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 import org.jenkinsci.Symbol;
 import hudson.Extension;
 import hudson.FilePath;
@@ -232,6 +233,7 @@ public class SimpleReferenceRecorder extends Recorder implements SimpleBuildStep
          *
          * @return the validation result
          */
+        @POST
         @SuppressWarnings("unused") // Used in jelly validation
         public FormValidation doCheckReferenceJob(@QueryParameter final String referenceJob) {
             return model.validateJob(referenceJob);

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.jelly
@@ -7,13 +7,13 @@
     <j:set var="s" value="${it.result.latestStatistics}" />
     <ul>
       <li>
+        New commits: ${s.commitCount} (from ${s.authorCount} authors in ${s.filesCount} files)
+      </li>
+      <li>
         New added lines: ${s.addedLines}
       </li>
       <li>
         New deleted lines: ${s.deletedLines}
-      </li>
-      <li>
-        New commits: ${s.commitCount} (from ${s.authorCount} authors in ${s.filesCount} files)
       </li>
     </ul>
   </t:summary>

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/Messages.properties
@@ -12,7 +12,7 @@ Table.Column.Author=Author
 
 TrendChart.Files.Legend.Label=#Files
 TrendChart.Loc.Legend.Label=#Lines Of Code
-TrendChart.Churn.Legend.Label=TotalChurn
+TrendChart.Churn.Legend.Label=Code Churn
 
 TrendChart.Churn.Legend.Added=Added
 TrendChart.Churn.Legend.Deleted=Deleted

--- a/src/main/resources/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder/config.jelly
@@ -1,8 +1,8 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/controls" >
 
   <f:entry title="${%title.referenceJob}" field="referenceJob" description="${%description.referenceJob}">
-    <f:combobox/>
+    <c:safe-combobox />
   </f:entry>
 
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/forensics/ArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/ArchitectureTest.java
@@ -1,5 +1,11 @@
 package io.jenkins.plugins.forensics;
 
+import javax.xml.parsers.SAXParser;
+
+import org.apache.commons.digester.Digester;
+import org.apache.commons.digester.xmlrules.DigesterLoader;
+import org.xml.sax.XMLReader;
+
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
@@ -7,6 +13,11 @@ import com.tngtech.archunit.lang.ArchRule;
 import edu.hm.hafner.util.ArchitectureRules;
 
 import io.jenkins.plugins.util.PluginArchitectureRules;
+
+import static com.tngtech.archunit.base.DescribedPredicate.*;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.*;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.*;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 
 /**
  * Defines several architecture rules for the static analysis model and parsers.
@@ -17,17 +28,51 @@ import io.jenkins.plugins.util.PluginArchitectureRules;
 @AnalyzeClasses(packages = "io.jenkins.plugins.forensics..")
 class ArchitectureTest {
     @ArchTest
+    static final ArchRule NO_TEST_API_CALLED = ArchitectureRules.NO_TEST_API_CALLED;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_ANNOTATION_USED = ArchitectureRules.NO_FORBIDDEN_ANNOTATION_USED;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
+
+    @ArchTest
     static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;
 
     @ArchTest
     static final ArchRule NO_PUBLIC_TEST_CLASSES = PluginArchitectureRules.NO_PUBLIC_TEST_CLASSES;
 
     @ArchTest
-    static final ArchRule NO_TEST_API_CALLED = ArchitectureRules.NO_TEST_API_CALLED;
-
-    @ArchTest
     static final ArchRule NO_FORBIDDEN_PACKAGE_ACCESSED = PluginArchitectureRules.NO_FORBIDDEN_PACKAGE_ACCESSED;
 
     @ArchTest
-    static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
+    static final ArchRule AJAX_PROXY_METHOD_MUST_BE_IN_PUBLIC_CLASS = PluginArchitectureRules.AJAX_PROXY_METHOD_MUST_BE_IN_PUBLIC_CLASS;
+
+    @ArchTest
+    static final ArchRule DATA_BOUND_CONSTRUCTOR_MUST_BE_IN_PUBLIC_CLASS = PluginArchitectureRules.DATA_BOUND_CONSTRUCTOR_MUST_BE_IN_PUBLIC_CLASS;
+
+    @ArchTest
+    static final ArchRule DATA_BOUND_SETTER_MUST_BE_IN_PUBLIC_CLASS = PluginArchitectureRules.DATA_BOUND_SETTER_MUST_BE_IN_PUBLIC_CLASS;
+
+    @ArchTest
+    static final ArchRule USE_POST_FOR_VALIDATION_END_POINTS = PluginArchitectureRules.USE_POST_FOR_VALIDATION_END_POINTS;
+
+    /** Digester must not be used directly, rather use a SecureDigester instance. */
+    @ArchTest
+    static final ArchRule NO_DIGESTER_CONSTRUCTOR_CALLED =
+            noClasses().that().doNotHaveSimpleName("SecureDigester")
+                    .should().callConstructor(Digester.class)
+                    .orShould().callConstructor(Digester.class, SAXParser.class)
+                    .orShould().callConstructor(Digester.class, XMLReader.class)
+                    .orShould().callMethod(DigesterLoader.class, "createDigester");
+
+    /** Test classes should not use Junit 4. */
+    // TODO: see https://github.com/TNG/ArchUnit/issues/136
+    @ArchTest
+    static final ArchRule NO_JUNIT_4 =
+            noClasses().that(doNot(
+                    have(simpleNameEndingWith("ITest"))
+                            .or(have(simpleNameStartingWith("Integration")))
+                            .or(have(simpleName("ToolsLister")))))
+                    .should().dependOnClassesThat().resideInAnyPackage("org.junit");
 }


### PR DESCRIPTION
Downstream PR of jenkinsci/plugin-util-api-plugin#66. 

Use `@POST` for field validation. For details see https://www.jenkins.io/doc/developer/security/form-validation/.