### PR TITLE
[JENKINS-64578] Support multiple SCM repositories per job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
 
     <dependency>
@@ -127,6 +128,13 @@
       <version>${plugin-util-api.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <jquery3-api.version>3.5.1-2</jquery3-api.version>
     <bootstrap4-api.version>4.5.3-1</bootstrap4-api.version>
     <data-tables-api.version>1.10.21-3</data-tables-api.version>
-    <echarts-api.version>4.9.0-2</echarts-api.version>
+    <echarts-api.version>4.9.0-3</echarts-api.version>
     <plugin-util-api.version>1.6.1</plugin-util-api.version>
 
   </properties>

--- a/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
@@ -89,7 +89,7 @@ public abstract class BlamerFactory implements ExtensionPoint {
             final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
         Collection<? extends SCM> scms = new ScmResolver().getScms(run, scm);
         if (scms.isEmpty()) {
-            logger.logInfo("-> No SCM found.");
+            logger.logInfo("-> No SCM found");
             return new NullBlamer();
         }
         return findAllExtensions().stream()

--- a/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
@@ -89,7 +89,7 @@ public abstract class BlamerFactory implements ExtensionPoint {
             final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
         Collection<? extends SCM> scms = new ScmResolver().getScms(run, scm);
         if (scms.isEmpty()) {
-            logger.logInfo("-> No SCM found");
+            logger.logInfo("-> no SCM found");
             return new NullBlamer();
         }
         return findAllExtensions().stream()

--- a/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
@@ -91,7 +91,7 @@ public abstract class BlamerFactory implements ExtensionPoint {
                 .map(blamerFactory -> blamerFactory.createBlamer(scm, run, workTree, listener, logger))
                 .flatMap(OPTIONAL_MAPPER)
                 .findFirst()
-                .orElse(new NullBlamer());
+                .orElse(createNullBlamer(logger));
     }
 
     private static Blamer createNullBlamer(final FilteredLog logger) {

--- a/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/blame/BlamerFactory.java
@@ -69,6 +69,31 @@ public abstract class BlamerFactory implements ExtensionPoint {
                 .orElseGet(() -> createNullBlamer(logger));
     }
 
+    /**
+     * Returns a blamer for the specified {@link SCM repository}.
+     *
+     * @param scm
+     *         the SCM repository
+     * @param run
+     *         the current build
+     * @param workTree
+     *         the working tree of the repository
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
+     * @return a blamer for the SCM of the specified build or a {@link NullBlamer} if the SCM is not supported
+     */
+    public static Blamer findBlamer(final SCM scm, final Run<?, ?> run,
+            final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
+        return findAllExtensions().stream()
+                .map(blamerFactory -> blamerFactory.createBlamer(scm, run, workTree, listener, logger))
+                .flatMap(OPTIONAL_MAPPER)
+                .findFirst()
+                .orElse(new NullBlamer());
+    }
+
     private static Blamer createNullBlamer(final FilteredLog logger) {
         if (findAllExtensions().isEmpty()) {
             logger.logInfo("-> No blamer installed yet. You need to install the 'git-forensics' plugin to enable blaming for Git.");

--- a/src/main/java/io/jenkins/plugins/forensics/miner/AbstractForensicsAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/AbstractForensicsAction.java
@@ -28,6 +28,10 @@ abstract class AbstractForensicsAction extends AsyncTrendJobAction<ForensicsBuil
         this.scmKey = scmKey;
     }
 
+    public String getScmKey() {
+        return scmKey;
+    }
+
     @Override
     protected Iterable<? extends BuildResult<ForensicsBuildAction>> createBuildHistory() {
         return () -> {

--- a/src/main/java/io/jenkins/plugins/forensics/miner/AbstractForensicsAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/AbstractForensicsAction.java
@@ -1,0 +1,51 @@
+package io.jenkins.plugins.forensics.miner;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import edu.hm.hafner.echarts.BuildResult;
+import edu.hm.hafner.echarts.ChartModelConfiguration;
+import edu.hm.hafner.echarts.LinesChartModel;
+
+import hudson.model.Job;
+
+import io.jenkins.plugins.echarts.AsyncTrendJobAction;
+import io.jenkins.plugins.echarts.BuildActionIterator;
+
+/**
+ * A job action displays a link on the side panel of a job that refers to the last build that contains forensic results
+ * (i.e. a {@link ForensicsBuildAction} with a {@link RepositoryStatistics} instance). This action also is responsible
+ * to render the historical trend via its associated 'floatingBox.jelly' view.
+ *
+ * @author Ullrich Hafner
+ */
+abstract class AbstractForensicsAction extends AsyncTrendJobAction<ForensicsBuildAction> {
+    private final String scmKey;
+
+    AbstractForensicsAction(final Job<?, ?> owner, final String scmKey) {
+        super(owner, ForensicsBuildAction.class);
+
+        this.scmKey = scmKey;
+    }
+
+    @Override
+    protected Iterable<? extends BuildResult<ForensicsBuildAction>> createBuildHistory() {
+        return () -> {
+            Predicate<ForensicsBuildAction> predicate = a -> scmKey.equals(a.getScmKey());
+            Optional<ForensicsBuildAction> latestAction = getOwner().getActions(ForensicsBuildAction.class)
+                    .stream()
+                    .filter(predicate)
+                    .findAny();
+
+            return new BuildActionIterator<>(ForensicsBuildAction.class, latestAction, predicate);
+        };
+    }
+
+    @Override
+    protected LinesChartModel createChartModel() {
+        return createChart(createBuildHistory(), new ChartModelConfiguration());
+    }
+
+    abstract LinesChartModel createChart(Iterable<? extends BuildResult<ForensicsBuildAction>> buildHistory,
+            ChartModelConfiguration configuration);
+}

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
@@ -23,11 +23,13 @@ import io.jenkins.plugins.util.BuildAction;
  */
 public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> implements StaplerProxy {
     private static final long serialVersionUID = -263122257268060032L;
+    private static final String DEFAULT_FILE_NAME = "repository-statistics.xml";
 
     private final int numberOfFiles;
     private final int miningDurationSeconds;
-    private String scmKey;
-    private final String fileName;
+
+    private String scmKey; // since 0.9.0
+    private String fileName; // since 0.9.0
 
     /**
      * Creates a new instance of {@link ForensicsBuildAction}.
@@ -98,12 +100,15 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
         if (scmKey == null) {
             scmKey = StringUtils.EMPTY;
         }
+        if (fileName == null) {
+            fileName = DEFAULT_FILE_NAME;
+        }
         return super.readResolve();
     }
 
     private String getFileName(final int number) {
         if (number == 0) {
-            return "repository-statistics.xml";
+            return DEFAULT_FILE_NAME;
         }
         return String.format("repository-statistics-%d.xml", number);
     }

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.util.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.kohsuke.stapler.StaplerProxy;
 import hudson.model.Action;
@@ -92,6 +93,7 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
     }
 
     @Override
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification = "Deserialization of instances that do not have all fields yet")
     protected Object readResolve() {
         if (scmKey == null) {
             scmKey = StringUtils.EMPTY;

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
@@ -185,4 +185,9 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
     public String getScmKey() {
         return scmKey;
     }
+
+    @Override
+    public String toString() {
+        return String.format("%s [%s]", urlName, scmKey);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
@@ -86,12 +86,16 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
     @VisibleForTesting
     ForensicsBuildAction(final Run<?, ?> owner, final RepositoryStatistics repositoryStatistics,
             final boolean canSerialize, final int miningDurationSeconds, final String scmKey, final int number) {
-        super(owner, repositoryStatistics, canSerialize);
+        super(owner, repositoryStatistics, false);
 
         numberOfFiles = repositoryStatistics.size();
         this.miningDurationSeconds = miningDurationSeconds;
         this.scmKey = scmKey;
         fileName = getFileName(number);
+
+        if (canSerialize) {
+            createXmlStream().write(owner.getRootDir().toPath().resolve(fileName), repositoryStatistics);
+        }
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
@@ -156,7 +156,8 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
 
     @Override
     public String getDisplayName() {
-        return Messages.ForensicsView_Title(scmKey);
+        return Messages.ForensicsView_Title(StringUtils.defaultIfBlank(
+                StringUtils.substringAfterLast(scmKey, '/'), scmKey));
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
@@ -146,7 +146,7 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
 
     @Override
     public String getDisplayName() {
-        return Messages.ForensicsView_Title();
+        return Messages.ForensicsView_Title(scmKey);
     }
 
     /**
@@ -156,7 +156,7 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
      */
     @Override
     public Object getTarget() {
-        return new ForensicsViewModel(getOwner(), getResult());
+        return new ForensicsViewModel(getOwner(), getResult(), scmKey);
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
@@ -115,18 +115,19 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
 
     @Override
     public Collection<? extends Action> getProjectActions() {
-        return Arrays.asList(new ForensicsJobAction(getOwner().getParent()),
-                new ForensicsCodeMetricAction(getOwner().getParent()));
+        return Arrays.asList(new ForensicsJobAction(getOwner().getParent(), scmKey),
+                new ForensicsCodeMetricAction(getOwner().getParent(), scmKey));
+    }
+
+    @Override
+    protected ForensicsJobAction createProjectAction() {
+        // This method actually is obsolete and will not be called anymore
+        return new ForensicsJobAction(getOwner().getParent(), scmKey);
     }
 
     @Override
     protected RepositoryStatisticsXmlStream createXmlStream() {
         return new RepositoryStatisticsXmlStream();
-    }
-
-    @Override
-    protected ForensicsJobAction createProjectAction() {
-        return new ForensicsJobAction(getOwner().getParent());
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsBuildAction.java
@@ -27,6 +27,7 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
 
     private final int numberOfFiles;
     private final int miningDurationSeconds;
+    private final String urlName;
 
     private String scmKey; // since 0.9.0
     private String fileName; // since 0.9.0
@@ -91,7 +92,9 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
         numberOfFiles = repositoryStatistics.size();
         this.miningDurationSeconds = miningDurationSeconds;
         this.scmKey = scmKey;
-        fileName = getFileName(number);
+
+        fileName = createFileName(number);
+        urlName = createUrlName(number);
 
         if (canSerialize) {
             createXmlStream().write(owner.getRootDir().toPath().resolve(fileName), repositoryStatistics);
@@ -110,11 +113,18 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
         return super.readResolve();
     }
 
-    private String getFileName(final int number) {
+    private String createFileName(final int number) {
         if (number == 0) {
             return DEFAULT_FILE_NAME;
         }
         return String.format("repository-statistics-%d.xml", number);
+    }
+
+    private String createUrlName(final int number) {
+        if (number == 0) {
+            return ForensicsJobAction.FORENSICS_ID;
+        }
+        return String.format("%s-%d", ForensicsJobAction.FORENSICS_ID, number);
     }
 
     @Override
@@ -161,7 +171,7 @@ public class ForensicsBuildAction extends BuildAction<RepositoryStatistics> impl
 
     @Override
     public String getUrlName() {
-        return ForensicsJobAction.FORENSICS_ID;
+        return urlName;
     }
 
     public int getNumberOfFiles() {

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsCodeMetricAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsCodeMetricAction.java
@@ -9,9 +9,6 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import hudson.model.Job;
 
-import io.jenkins.plugins.echarts.AsyncTrendJobAction;
-import io.jenkins.plugins.echarts.BuildActionIterator;
-
 /**
  * A job action displays a link on the side panel of a job that refers to the last build that contains forensic results
  * (i.e. a {@link ForensicsBuildAction} with a {@link RepositoryStatistics} instance). This action also is responsible
@@ -19,9 +16,7 @@ import io.jenkins.plugins.echarts.BuildActionIterator;
  *
  * @author Giulia Del Bravo
  */
-public class ForensicsCodeMetricAction extends AsyncTrendJobAction<ForensicsBuildAction> {
-    private final String scmKey;
-
+public class ForensicsCodeMetricAction extends AbstractForensicsAction {
     /**
      * Creates a new instance of {@link ForensicsCodeMetricAction}.
      *
@@ -43,15 +38,13 @@ public class ForensicsCodeMetricAction extends AsyncTrendJobAction<ForensicsBuil
      *         key of the repository
      */
     public ForensicsCodeMetricAction(final Job<?, ?> owner, final String scmKey) {
-        super(owner, ForensicsBuildAction.class);
-
-        this.scmKey = scmKey;
+        super(owner, scmKey);
     }
 
-
     @Override
-    protected LinesChartModel createChartModel() {
-        return new ForensicsCodeMetricTrendChart().create(createBuildHistory(), new ChartModelConfiguration());
+    LinesChartModel createChart(final Iterable<? extends BuildResult<ForensicsBuildAction>> buildHistory,
+            final ChartModelConfiguration configuration) {
+        return new ForensicsCodeMetricTrendChart().create(buildHistory, configuration);
     }
 
     /**
@@ -74,11 +67,5 @@ public class ForensicsCodeMetricAction extends AsyncTrendJobAction<ForensicsBuil
     @Override
     public String getUrlName() {
         return null;
-    }
-
-    @Override
-    protected Iterable<? extends BuildResult<ForensicsBuildAction>> createBuildHistory() {
-        return () -> new BuildActionIterator<>(ForensicsBuildAction.class, getLatestAction(),
-                a -> scmKey.equals(a.getScmKey()));
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsCodeMetricAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsCodeMetricAction.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.forensics.miner;
 
+import org.apache.commons.lang3.StringUtils;
+
+import edu.hm.hafner.echarts.BuildResult;
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -7,6 +10,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.Job;
 
 import io.jenkins.plugins.echarts.AsyncTrendJobAction;
+import io.jenkins.plugins.echarts.BuildActionIterator;
 
 /**
  * A job action displays a link on the side panel of a job that refers to the last build that contains forensic results
@@ -16,16 +20,34 @@ import io.jenkins.plugins.echarts.AsyncTrendJobAction;
  * @author Giulia Del Bravo
  */
 public class ForensicsCodeMetricAction extends AsyncTrendJobAction<ForensicsBuildAction> {
+    private final String scmKey;
 
     /**
      * Creates a new instance of {@link ForensicsCodeMetricAction}.
      *
      * @param owner
      *         the job that owns this action
+     * @deprecated use {@link #ForensicsCodeMetricAction(Job, String)}
      */
+    @Deprecated
     public ForensicsCodeMetricAction(final Job<?, ?> owner) {
-        super(owner, ForensicsBuildAction.class);
+        this(owner, StringUtils.EMPTY);
     }
+
+    /**
+     * Creates a new instance of {@link ForensicsCodeMetricAction}.
+     *
+     * @param owner
+     *         the job that owns this action
+     * @param scmKey
+     *         key of the repository
+     */
+    public ForensicsCodeMetricAction(final Job<?, ?> owner, final String scmKey) {
+        super(owner, ForensicsBuildAction.class);
+
+        this.scmKey = scmKey;
+    }
+
 
     @Override
     protected LinesChartModel createChartModel() {
@@ -52,5 +74,11 @@ public class ForensicsCodeMetricAction extends AsyncTrendJobAction<ForensicsBuil
     @Override
     public String getUrlName() {
         return null;
+    }
+
+    @Override
+    protected Iterable<? extends BuildResult<ForensicsBuildAction>> createBuildHistory() {
+        return () -> new BuildActionIterator<>(ForensicsBuildAction.class, getLatestAction(),
+                a -> scmKey.equals(a.getScmKey()));
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
@@ -9,9 +9,6 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import hudson.model.Job;
 
-import io.jenkins.plugins.echarts.AsyncTrendJobAction;
-import io.jenkins.plugins.echarts.BuildActionIterator;
-
 /**
  * A job action displays a link on the side panel of a job that refers to the last build that contains forensic results
  * (i.e. a {@link ForensicsBuildAction} with a {@link RepositoryStatistics} instance). This action also is responsible
@@ -19,11 +16,9 @@ import io.jenkins.plugins.echarts.BuildActionIterator;
  *
  * @author Ullrich Hafner
  */
-public class ForensicsJobAction extends AsyncTrendJobAction<ForensicsBuildAction> {
+public class ForensicsJobAction extends AbstractForensicsAction {
     static final String SMALL_ICON = "/plugin/forensics-api/icons/forensics-24x24.png";
     static final String FORENSICS_ID = "forensics";
-
-    private final String scmKey;
 
     /**
      * Creates a new instance of {@link ForensicsJobAction}.
@@ -46,9 +41,7 @@ public class ForensicsJobAction extends AsyncTrendJobAction<ForensicsBuildAction
      *         key of the repository
      */
     public ForensicsJobAction(final Job<?, ?> owner, final String scmKey) {
-        super(owner, ForensicsBuildAction.class);
-
-        this.scmKey = scmKey;
+        super(owner, scmKey);
     }
 
     @Override
@@ -74,13 +67,8 @@ public class ForensicsJobAction extends AsyncTrendJobAction<ForensicsBuildAction
     }
 
     @Override
-    protected LinesChartModel createChartModel() {
-        return new FilesCountTrendChart().create(createBuildHistory(), new ChartModelConfiguration());
-    }
-
-    @Override
-    protected Iterable<? extends BuildResult<ForensicsBuildAction>> createBuildHistory() {
-        return () -> new BuildActionIterator<>(ForensicsBuildAction.class, getLatestAction(),
-                a -> scmKey.equals(a.getScmKey()));
+    LinesChartModel createChart(final Iterable<? extends BuildResult<ForensicsBuildAction>> buildHistory,
+            final ChartModelConfiguration configuration) {
+        return new FilesCountTrendChart().create(buildHistory, configuration);
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
@@ -55,5 +55,4 @@ public class ForensicsJobAction extends AsyncTrendJobAction<ForensicsBuildAction
     protected LinesChartModel createChartModel() {
         return new FilesCountTrendChart().create(createBuildHistory(), new ChartModelConfiguration());
     }
-
 }

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
@@ -46,7 +46,7 @@ public class ForensicsJobAction extends AbstractForensicsAction {
 
     @Override
     public String getDisplayName() {
-        return Messages.ForensicsView_Title(getScmKey());
+        return Messages.Forensics_Action();
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
@@ -46,7 +46,7 @@ public class ForensicsJobAction extends AbstractForensicsAction {
 
     @Override
     public String getDisplayName() {
-        return Messages.ForensicsView_Title();
+        return Messages.ForensicsView_Title(getScmKey());
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsJobAction.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.forensics.miner;
 
+import org.apache.commons.lang3.StringUtils;
+
+import edu.hm.hafner.echarts.BuildResult;
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -7,6 +10,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.Job;
 
 import io.jenkins.plugins.echarts.AsyncTrendJobAction;
+import io.jenkins.plugins.echarts.BuildActionIterator;
 
 /**
  * A job action displays a link on the side panel of a job that refers to the last build that contains forensic results
@@ -19,14 +23,32 @@ public class ForensicsJobAction extends AsyncTrendJobAction<ForensicsBuildAction
     static final String SMALL_ICON = "/plugin/forensics-api/icons/forensics-24x24.png";
     static final String FORENSICS_ID = "forensics";
 
+    private final String scmKey;
+
     /**
      * Creates a new instance of {@link ForensicsJobAction}.
      *
      * @param owner
      *         the job that owns this action
+     * @deprecated use {@link #ForensicsJobAction(Job, String)}
      */
+    @Deprecated
     public ForensicsJobAction(final Job<?, ?> owner) {
+        this(owner, StringUtils.EMPTY);
+    }
+
+    /**
+     * Creates a new instance of {@link ForensicsJobAction}.
+     *
+     * @param owner
+     *         the job that owns this action
+     * @param scmKey
+     *         key of the repository
+     */
+    public ForensicsJobAction(final Job<?, ?> owner, final String scmKey) {
         super(owner, ForensicsBuildAction.class);
+
+        this.scmKey = scmKey;
     }
 
     @Override
@@ -54,5 +76,11 @@ public class ForensicsJobAction extends AsyncTrendJobAction<ForensicsBuildAction
     @Override
     protected LinesChartModel createChartModel() {
         return new FilesCountTrendChart().create(createBuildHistory(), new ChartModelConfiguration());
+    }
+
+    @Override
+    protected Iterable<? extends BuildResult<ForensicsBuildAction>> createBuildHistory() {
+        return () -> new BuildActionIterator<>(ForensicsBuildAction.class, getLatestAction(),
+                a -> scmKey.equals(a.getScmKey()));
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsViewModel.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsViewModel.java
@@ -25,6 +25,7 @@ import io.jenkins.plugins.forensics.util.CommitDecoratorFactory;
 public class ForensicsViewModel extends DefaultAsyncTableContentProvider implements ModelObject {
     private final Run<?, ?> owner;
     private final RepositoryStatistics repositoryStatistics;
+    private final String scmKey;
 
     /**
      * Creates a new {@link ForensicsViewModel} instance.
@@ -33,12 +34,15 @@ public class ForensicsViewModel extends DefaultAsyncTableContentProvider impleme
      *         the build as owner of this view
      * @param repositoryStatistics
      *         the statistics to show in the view
+     * @param scmKey
+     *         key of the repository
      */
-    ForensicsViewModel(final Run<?, ?> owner, final RepositoryStatistics repositoryStatistics) {
+    ForensicsViewModel(final Run<?, ?> owner, final RepositoryStatistics repositoryStatistics, final String scmKey) {
         super();
 
         this.owner = owner;
         this.repositoryStatistics = repositoryStatistics;
+        this.scmKey = scmKey;
     }
 
     public Run<?, ?> getOwner() {
@@ -47,7 +51,7 @@ public class ForensicsViewModel extends DefaultAsyncTableContentProvider impleme
 
     @Override
     public String getDisplayName() {
-        return Messages.ForensicsView_Title();
+        return Messages.ForensicsView_Title(scmKey);
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/forensics/miner/MinerFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/MinerFactory.java
@@ -60,7 +60,9 @@ public abstract class MinerFactory implements ExtensionPoint {
      *         a logger to report error messages
      *
      * @return a miner for the SCM of the specified build or a {@link NullMiner} if the SCM is not supported
+     * @deprecated use {@link #findMiner(SCM, Run, FilePath, TaskListener, FilteredLog)}
      */
+    @Deprecated
     public static RepositoryMiner findMiner(final Run<?, ?> run,
             final Collection<FilePath> scmDirectories, final TaskListener listener, final FilteredLog logger) {
         return scmDirectories.stream()
@@ -106,7 +108,7 @@ public abstract class MinerFactory implements ExtensionPoint {
      *
      * @return a miner for the SCM of the specified build or a {@link NullMiner} if the SCM is not supported
      */
-    public static RepositoryMiner findMiner(final SCM scm, final Run<?, ?> run,
+    static RepositoryMiner findMiner(final SCM scm, final Run<?, ?> run,
             final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
         return findAllExtensions().stream()
                 .map(minerFactory -> minerFactory.createMiner(scm, run, workTree, listener, logger))

--- a/src/main/java/io/jenkins/plugins/forensics/miner/MinerFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/MinerFactory.java
@@ -80,8 +80,6 @@ public abstract class MinerFactory implements ExtensionPoint {
         return new NullMiner();
     }
 
-
-
     private static Optional<RepositoryMiner> findMiner(final Run<?, ?> run, final FilePath workTree,
             final TaskListener listener, final FilteredLog logger) {
         SCM scm = new ScmResolver().getScm(run);
@@ -90,6 +88,31 @@ public abstract class MinerFactory implements ExtensionPoint {
                 .map(minerFactory -> minerFactory.createMiner(scm, run, workTree, listener, logger))
                 .flatMap(OPTIONAL_MAPPER)
                 .findFirst();
+    }
+
+    /**
+     * Returns a miner for the repository of the specified {@link Run build}.
+     *
+     * @param scm
+     *         the SCM repository
+     * @param run
+     *         the current build
+     * @param workTree
+     *         the working tree of the repository
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
+     * @return a miner for the SCM of the specified build or a {@link NullMiner} if the SCM is not supported
+     */
+    public static RepositoryMiner findMiner(final SCM scm, final Run<?, ?> run,
+            final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
+        return findAllExtensions().stream()
+                .map(minerFactory -> minerFactory.createMiner(scm, run, workTree, listener, logger))
+                .flatMap(OPTIONAL_MAPPER)
+                .findFirst()
+                .orElse(new NullMiner());
     }
 
     private static List<MinerFactory> findAllExtensions() {

--- a/src/main/java/io/jenkins/plugins/forensics/miner/MinerService.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/MinerService.java
@@ -1,10 +1,15 @@
 package io.jenkins.plugins.forensics.miner;
 
+import java.util.List;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.util.FilteredLog;
 
 import hudson.model.Run;
+
+import io.jenkins.plugins.util.BuildAction;
 
 /**
  * Queries the repository statistics of a build for a subselection of results.
@@ -12,7 +17,7 @@ import hudson.model.Run;
  * @author Ullrich Hafner
  */
 public class MinerService {
-    static final String NO_MINER_CONFIGURED_ERROR = "Repository miner is not configured, skipping mining";
+    static final String NO_MINER_ERROR = "<a href=\"https://github.com/jenkinsci/forensics-api-plugin\">Repository miner</a> is not configured, skipping repository mining";
 
     /**
      * Queries the statistics for the selected files of the aggregated repository statistics of the specified build.
@@ -25,25 +30,51 @@ public class MinerService {
      *         the logger
      *
      * @return the statistics for the selected files, if available
+     * @deprecated use {@link #queryStatisticsFor(String, Run, Set, FilteredLog)}
      */
+    @Deprecated
     public RepositoryStatistics queryStatisticsFor(final Run<?, ?> build, final Set<String> files,
             final FilteredLog log) {
+        return queryStatisticsFor(StringUtils.EMPTY, build, files, log);
+    }
+
+    /**
+     * Queries the statistics for the selected files of the aggregated repository statistics of the specified build.
+     *
+     * @param scm
+     *         the SCM to get the results from (can be empty if there is just a single repository used)
+     * @param build
+     *         the build
+     * @param files
+     *         the files to get the statistics for
+     * @param logger
+     *         the logger
+     *
+     * @return the statistics for the selected files, if available
+     */
+    public RepositoryStatistics queryStatisticsFor(final String scm, final Run<?, ?> build,
+            final Set<String> files, final FilteredLog logger) {
         RepositoryStatistics selected = new RepositoryStatistics();
 
-        ForensicsBuildAction action = build.getAction(ForensicsBuildAction.class);
-        if (action == null) {
-            log.logInfo(NO_MINER_CONFIGURED_ERROR);
-
+        List<ForensicsBuildAction> actions = build.getActions(ForensicsBuildAction.class);
+        if (actions.isEmpty()) {
+            logger.logInfo(NO_MINER_ERROR);
             return selected;
         }
 
-        RepositoryStatistics everything = action.getResult();
+        RepositoryStatistics everything = actions.stream()
+                .filter(a -> a.getScmKey().contains(scm))
+                .findAny()
+                .map(BuildAction::getResult)
+                .orElse(new RepositoryStatistics());
+        logger.logInfo("Extracting repository statistics for affected files (%d of %d)", files.size(), everything.size());
+
         for (String file : files) {
             if (everything.contains(file)) {
                 selected.add(everything.get(file));
             }
             else {
-                log.logError("No statistics found for file '%s'", file);
+                logger.logError("No statistics found for file '%s'", file);
             }
         }
         return selected;

--- a/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
@@ -97,8 +97,8 @@ public class RepositoryMinerStep extends Recorder implements SimpleBuildStep {
 
             logHandler.log(logger);
             int miningDurationSeconds = (int) (1 + (System.nanoTime() - startOfMining) / 1_000_000_000L);
-            run.addAction(
-                    new ForensicsBuildAction(run, addedRepositoryStatistics, miningDurationSeconds, scm, number++));
+            run.addAction(new ForensicsBuildAction(run, addedRepositoryStatistics, miningDurationSeconds,
+                    repository.getKey(), number++));
         }
     }
 
@@ -114,7 +114,7 @@ public class RepositoryMinerStep extends Recorder implements SimpleBuildStep {
             List<ForensicsBuildAction> actions = build.getActions(ForensicsBuildAction.class);
             if (!actions.isEmpty()) {
                 return actions.stream()
-                        .filter(a -> repository.equals(a.getScmKey()))
+                        .filter(a -> a.getScmKey().contains(repository))
                         .findAny()
                         .map(BuildAction::getResult)
                         .orElse(new RepositoryStatistics());

--- a/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
@@ -1,8 +1,6 @@
 package io.jenkins.plugins.forensics.miner;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -81,7 +79,7 @@ public class RepositoryMinerStep extends Recorder implements SimpleBuildStep {
     private void mineRepositories(final Run<?, ?> run, final FilePath workspace, final TaskListener listener)
             throws InterruptedException {
         int number = 0;
-        for (SCM repository : getRepositories(run)) {
+        for (SCM repository : new ScmResolver().getScms(run, getScm())) {
             long startOfMining = System.nanoTime();
             LogHandler logHandler = new LogHandler(listener, "Forensics");
 
@@ -100,13 +98,6 @@ public class RepositoryMinerStep extends Recorder implements SimpleBuildStep {
             run.addAction(new ForensicsBuildAction(run, addedRepositoryStatistics, miningDurationSeconds,
                     repository.getKey(), number++));
         }
-    }
-
-    private Collection<? extends SCM> getRepositories(final Run<?, ?> run) {
-        return new ScmResolver().getScms(run)
-                .stream()
-                .filter(r -> r.getKey().contains(getScm()))
-                .collect(Collectors.toList());
     }
 
     private RepositoryStatistics previousBuildStatistics(final String repository, final Run<?, ?> run) {

--- a/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
@@ -87,7 +87,7 @@ public class RepositoryMinerStep extends Recorder implements SimpleBuildStep {
 
             FilteredLog logger = new FilteredLog("Errors while mining " + repository);
             logger.logInfo("Creating SCM miner to obtain statistics for affected repository files");
-            logger.logInfo("-> checking SCM `%s`", repository);
+            logger.logInfo("-> checking SCM '%s'", repository.getKey());
 
             RepositoryMiner miner = MinerFactory.findMiner(repository, run, workspace, listener, logger);
             logHandler.log(logger);

--- a/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
@@ -45,6 +45,7 @@ public abstract class ReferenceRecorder extends SimpleReferenceRecorder {
 
     private String defaultBranch = DEFAULT_BRANCH;
     private boolean latestBuildIfNotFound = false;
+    private String scm = StringUtils.EMPTY;
 
     /**
      * Creates a new instance of {@link ReferenceRecorder}.
@@ -87,6 +88,22 @@ public abstract class ReferenceRecorder extends SimpleReferenceRecorder {
 
     public String getDefaultBranch() {
         return defaultBranch;
+    }
+
+    /**
+     * Sets the SCM that should be used to find the reference build for. The reference recorder will select the SCM
+     * based on a substring comparison, there is no need to specify the full name.
+     *
+     * @param scm
+     *         the ID of the SCM to use (a substring of the full ID)
+     */
+    @DataBoundSetter
+    public void setScm(final String scm) {
+        this.scm = scm;
+    }
+
+    public String getScm() {
+        return scm;
     }
 
     private String getReferenceBranch() {

--- a/src/main/java/io/jenkins/plugins/forensics/reference/package-info.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Provides API classes to obtain a reference build.
+ */
+@DefaultAnnotation(NonNull.class)
+package io.jenkins.plugins.forensics.reference;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/src/main/java/io/jenkins/plugins/forensics/util/CommitDecoratorFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/util/CommitDecoratorFactory.java
@@ -47,10 +47,27 @@ public abstract class CommitDecoratorFactory implements ExtensionPoint {
      *
      * @return a commit decorator for the SCM of the specified build or a {@link NullDecorator} if the SCM is not
      *         supported or if the SCM does not provide a {@link RepositoryBrowser} implementation
+     * @deprecated use {@link #findCommitDecorator(SCM, FilteredLog)}
      */
+    @Deprecated
     public static CommitDecorator findCommitDecorator(final Run<?, ?> run, final FilteredLog logger) {
         SCM scm = new ScmResolver().getScm(run);
 
+        return findCommitDecorator(scm, logger);
+    }
+
+    /**
+     * Returns a commit decorator for the specified {@link SCM scm}.
+     *
+     * @param scm
+     *         the SCM to get the decorator for
+     * @param logger
+     *         a logger to report error messages
+     *
+     * @return a commit decorator for the specified SCM or a {@link NullDecorator} if the SCM is not
+     *         supported or if the SCM does not provide a {@link RepositoryBrowser} implementation
+     */
+    public static CommitDecorator findCommitDecorator(final SCM scm, final FilteredLog logger) {
         return findAllExtensions().stream()
                 .map(factory -> factory.createCommitDecorator(scm, logger))
                 .flatMap(OPTIONAL_MAPPER)

--- a/src/main/java/io/jenkins/plugins/forensics/util/ScmResolver.java
+++ b/src/main/java/io/jenkins/plugins/forensics/util/ScmResolver.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
@@ -39,6 +40,23 @@ public class ScmResolver {
             return new NullSCM();
         }
         return scms.iterator().next();
+    }
+
+    /**
+     * Returns the SCMs in a given build, filtered by the name.
+     *
+     * @param run
+     *         the build to get the SCMs from
+     * @param keyFilter
+     *         substring that must be part of the SCM key
+     *
+     * @return the SCMs
+     */
+    public Collection<? extends SCM> getScms(final Run<?, ?> run, final String keyFilter) {
+        return getScms(run)
+                .stream()
+                .filter(r -> r.getKey().contains(keyFilter))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/forensics/util/ScmResolver.java
+++ b/src/main/java/io/jenkins/plugins/forensics/util/ScmResolver.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.forensics.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -68,6 +69,19 @@ public class ScmResolver {
      * @return the SCMs
      */
     public Collection<? extends SCM> getScms(final Run<?, ?> run) {
+        Collection<? extends SCM> allScms = findScms(run);
+        Set<String> ids = allScms.stream().map(SCM::getKey).collect(Collectors.toSet());
+        List<SCM> uniqueScms = new ArrayList<>();
+        for (SCM scm : allScms) {
+            if (ids.contains(scm.getKey())) {
+                uniqueScms.add(scm);
+                ids.remove(scm.getKey());
+            }
+        }
+        return uniqueScms;
+    }
+
+    private Collection<? extends SCM> findScms(final Run<?, ?> run) {
         if (run instanceof AbstractBuild) {
             return extractFromProject((AbstractBuild<?, ?>) run);
         }
@@ -101,7 +115,7 @@ public class ScmResolver {
     }
 
     private Collection<? extends SCM> extractFromProject(final AbstractBuild<?, ?> run) {
-        AbstractProject<?, ?> project = run.getProject();
+        AbstractProject<?, ?> project = run.getParent();
         if (project.getScm() != null) {
             return asCollection(project.getScm());
         }

--- a/src/main/resources/forensics/scm.jelly
+++ b/src/main/resources/forensics/scm.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+
+  <st:documentation>
+    Provides a text box to select the SCM.
+  </st:documentation>
+
+  <f:entry title="${%title.scm}" field="scm" description="${%description.scm}">
+    <f:textbox/>
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/forensics/scm.properties
+++ b/src/main/resources/forensics/scm.properties
@@ -1,0 +1,2 @@
+title.scm=SCM Key
+description.scm=Specify the key of your repository (substring) if you are using multiple SCMs in your job.

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.jelly
@@ -2,10 +2,13 @@
 <j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
 
   <t:summary icon="/plugin/forensics-api/icons/forensics-48x48.png">
-    ${%title}: <a href="forensics">${%summary(size(it.result))}</a>
-    (total lines of code: ${it.result.totalLinesOfCode}, total churn: ${it.result.totalChurn})
+    ${%title}: ${it.scmKey}
     <j:set var="s" value="${it.result.latestStatistics}" />
     <ul>
+      <li>
+        <a href="forensics">${%summary(size(it.result))}</a>
+        (total lines of code: ${it.result.totalLinesOfCode}, total churn: ${it.result.totalChurn})
+      </li>
       <li>
         New commits: ${s.commitCount} (from ${s.authorCount} authors in ${s.filesCount} files)
       </li>
@@ -14,6 +17,9 @@
       </li>
       <li>
         New deleted lines: ${s.deletedLines}
+      </li>
+      <li>
+        Miner runtime: ${it.miningDurationSeconds}
       </li>
     </ul>
   </t:summary>

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.jelly
@@ -6,7 +6,7 @@
     <j:set var="s" value="${it.result.latestStatistics}" />
     <ul>
       <li>
-        <a href="forensics">${%summary(size(it.result))}</a>
+        <a href="${it.urlName}">${%summary(size(it.result))}</a>
         (total lines of code: ${it.result.totalLinesOfCode}, total churn: ${it.result.totalChurn})
       </li>
       <li>
@@ -19,7 +19,7 @@
         New deleted lines: ${s.deletedLines}
       </li>
       <li>
-        Miner runtime: ${it.miningDurationSeconds}
+        Miner runtime: ${it.miningDurationSeconds} seconds
       </li>
     </ul>
   </t:summary>

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.properties
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.properties
@@ -1,2 +1,2 @@
-title=SCM Statistics
+title=SCM Forensics
 summary={0} repository files

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/Messages.properties
@@ -17,7 +17,7 @@ TrendChart.Churn.Legend.Label=Code Churn
 TrendChart.Churn.Legend.Added=Added
 TrendChart.Churn.Legend.Deleted=Deleted
 
-ForensicsView.Title=SCM Forensics
+ForensicsView.Title=SCM Forensics of ''{0}''
 FileView.Title=Details of {0}
 Step.Name=Mine SCM repository
 TrendChart.Added.Legend.Label=Added lines

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/Messages.properties
@@ -17,6 +17,7 @@ TrendChart.Churn.Legend.Label=Code Churn
 TrendChart.Churn.Legend.Added=Added
 TrendChart.Churn.Legend.Deleted=Deleted
 
+Forensics.Action=SCM Forensics
 ForensicsView.Title=SCM Forensics of ''{0}''
 FileView.Title=Details of {0}
 Step.Name=Mine SCM repository

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/RepositoryMinerStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/RepositoryMinerStep/config.jelly
@@ -1,5 +1,6 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" >
+<j:jelly xmlns:j="jelly:core" xmlns:f="/forensics" >
 
+  <f:scm/>
 
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/forensics/miner/MinerServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/miner/MinerServiceTest.java
@@ -1,7 +1,8 @@
 package io.jenkins.plugins.forensics.miner;
 
-import java.util.Collections;
+import java.util.Arrays;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.util.FilteredLog;
@@ -11,6 +12,7 @@ import hudson.model.Run;
 import io.jenkins.plugins.forensics.miner.FileStatistics.FileStatisticsBuilder;
 
 import static io.jenkins.plugins.forensics.assertions.Assertions.*;
+import static java.util.Collections.*;
 import static org.assertj.core.util.Sets.*;
 import static org.mockito.Mockito.*;
 
@@ -21,32 +23,33 @@ import static org.mockito.Mockito.*;
  */
 class MinerServiceTest {
     private static final String EXISTING_FILE = "file.txt";
+    private static final String NO_SCM_FILTER = StringUtils.EMPTY;
 
     @Test
     void shouldReturnEmptyStatisticsIfActionIsMissing() {
         MinerService service = new MinerService();
         FilteredLog logger = createLogger();
-        RepositoryStatistics statistics = service.queryStatisticsFor(mock(Run.class),
-                newLinkedHashSet(EXISTING_FILE), logger);
+
+        RepositoryStatistics statistics = service.queryStatisticsFor(
+                NO_SCM_FILTER, mock(Run.class), newLinkedHashSet(EXISTING_FILE), logger);
 
         assertThat(statistics).isEmpty();
         assertThat(logger.getErrorMessages()).isEmpty();
-        assertThat(logger.getInfoMessages()).contains(MinerService.NO_MINER_CONFIGURED_ERROR);
+        assertThat(logger.getInfoMessages()).contains(MinerService.NO_MINER_ERROR);
     }
 
     @Test
     void shouldReturnEmptyStatisticsIfFilesAreEmpty() {
         MinerService service = new MinerService();
-        Run<?, ?> build = mock(Run.class);
-        when(build.getAction(ForensicsBuildAction.class)).thenReturn(mock(ForensicsBuildAction.class));
-
         FilteredLog logger = createLogger();
-        RepositoryStatistics statistics = service.queryStatisticsFor(build,
-                Collections.emptySet(), logger);
+
+        RepositoryStatistics statistics = service.queryStatisticsFor(
+                NO_SCM_FILTER, createBuild(createAction("scm")), emptySet(), logger);
 
         assertThat(statistics).isEmpty();
         assertThat(logger.getErrorMessages()).isEmpty();
-        assertThat(logger.getInfoMessages()).isEmpty();
+        assertThat(logger.getInfoMessages())
+                .containsExactly("Extracting repository statistics for affected files (0 of 0)");
     }
 
     @Test
@@ -56,12 +59,34 @@ class MinerServiceTest {
         Run<?, ?> build = configureBuildWithSingleMiningResult();
 
         FilteredLog logger = createLogger();
-        RepositoryStatistics statistics = service.queryStatisticsFor(build,
-                newLinkedHashSet(EXISTING_FILE), logger);
+        RepositoryStatistics statistics = service.queryStatisticsFor(
+                NO_SCM_FILTER, build, newLinkedHashSet(EXISTING_FILE), logger);
 
         assertThat(statistics).isNotEmpty().hasFiles(EXISTING_FILE);
         assertThat(logger.getErrorMessages()).isEmpty();
-        assertThat(logger.getInfoMessages()).isEmpty();
+        assertThat(logger.getInfoMessages())
+                .containsExactly("Extracting repository statistics for affected files (1 of 1)");
+    }
+
+    @Test
+    void shouldFindSelectedFileForSelectedRepositories() {
+        ForensicsBuildAction actionWithResult = createAction("select");
+        appendResult(actionWithResult);
+
+        Run<?, ?> build = mock(Run.class);
+        when(build.getActions(ForensicsBuildAction.class))
+                .thenAnswer(i -> Arrays.asList(createAction("scm"), actionWithResult));
+
+        MinerService service = new MinerService();
+
+        FilteredLog logger = createLogger();
+        RepositoryStatistics statistics = service.queryStatisticsFor(
+                "select", build, newLinkedHashSet(EXISTING_FILE), logger);
+
+        assertThat(statistics).isNotEmpty().hasFiles(EXISTING_FILE);
+        assertThat(logger.getErrorMessages()).isEmpty();
+        assertThat(logger.getInfoMessages())
+                .containsExactly("Extracting repository statistics for affected files (1 of 1)");
     }
 
     @Test
@@ -71,12 +96,13 @@ class MinerServiceTest {
         Run<?, ?> build = configureBuildWithSingleMiningResult();
 
         FilteredLog logger = createLogger();
-        RepositoryStatistics statistics = service.queryStatisticsFor(build,
-                newLinkedHashSet("not-existing"), logger);
+        RepositoryStatistics statistics = service.queryStatisticsFor(
+                NO_SCM_FILTER, build, newLinkedHashSet("not-existing"), logger);
 
         assertThat(statistics).isEmpty();
         assertThat(logger.getErrorMessages()).isNotEmpty().contains("No statistics found for file 'not-existing'");
-        assertThat(logger.getInfoMessages()).isEmpty();
+        assertThat(logger.getInfoMessages())
+                .containsExactly("Extracting repository statistics for affected files (1 of 1)");
     }
 
     @Test
@@ -86,24 +112,40 @@ class MinerServiceTest {
         Run<?, ?> build = configureBuildWithSingleMiningResult();
 
         FilteredLog logger = createLogger();
-        RepositoryStatistics statistics = service.queryStatisticsFor(build,
-                newLinkedHashSet(EXISTING_FILE, "not-existing"), logger);
+        RepositoryStatistics statistics = service.queryStatisticsFor(
+                NO_SCM_FILTER, build, newLinkedHashSet(EXISTING_FILE, "not-existing"), logger);
 
         assertThat(statistics).isNotEmpty().hasFiles(EXISTING_FILE);
         assertThat(logger.getErrorMessages()).isNotEmpty().contains("No statistics found for file 'not-existing'");
-        assertThat(logger.getInfoMessages()).isEmpty();
+        assertThat(logger.getInfoMessages())
+                .containsExactly("Extracting repository statistics for affected files (2 of 1)");
     }
 
     private Run<?, ?> configureBuildWithSingleMiningResult() {
-        Run<?, ?> build = mock(Run.class);
-        ForensicsBuildAction action = mock(ForensicsBuildAction.class);
-        when(build.getAction(ForensicsBuildAction.class)).thenReturn(action);
+        ForensicsBuildAction action = createAction("scm");
 
+        appendResult(action);
+
+        return createBuild(action);
+    }
+
+    private void appendResult(final ForensicsBuildAction action) {
         RepositoryStatistics everything = new RepositoryStatistics();
         everything.add(new FileStatisticsBuilder().build(EXISTING_FILE));
-
         when(action.getResult()).thenReturn(everything);
+    }
+
+    private Run<?, ?> createBuild(final ForensicsBuildAction action) {
+        Run<?, ?> build = mock(Run.class);
+        when(build.getActions(ForensicsBuildAction.class))
+                .thenAnswer(i -> singletonList(action));
         return build;
+    }
+
+    private ForensicsBuildAction createAction(final String scm) {
+        ForensicsBuildAction action = mock(ForensicsBuildAction.class);
+        when(action.getScmKey()).thenReturn(scm);
+        return action;
     }
 
     private FilteredLog createLogger() {

--- a/src/test/java/io/jenkins/plugins/forensics/util/ScmResolverTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/util/ScmResolverTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Andreas Reiser
  */
+@SuppressWarnings("rawtypes")
 class ScmResolverTest {
     @Test
     void shouldCreateNullBlamerOnNullScm() {
@@ -37,7 +38,7 @@ class ScmResolverTest {
     }
 
     @Test
-    void shouldCreateGitBlamerOnGitScm() {
+    void shouldResolveScmOnGitScm() {
         AbstractProject job = mock(AbstractProject.class);
         SCM scm = mock(SCM.class);
         when(job.getScm()).thenReturn(scm);
@@ -47,7 +48,7 @@ class ScmResolverTest {
     }
 
     @Test
-    void shouldCreateGitBlamerOnGitScmOnRoot() {
+    void shouldResolveScmOnGitScmOnRoot() {
         AbstractProject job = mock(AbstractProject.class);
 
         AbstractProject root = mock(AbstractProject.class);
@@ -62,7 +63,7 @@ class ScmResolverTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void shouldCreateGitBlamerForPipeline() {
+    void shouldResolveScmForPipeline() {
         Job pipeline = mock(Job.class, withSettings().extraInterfaces(SCMTriggerItem.class));
 
         SCM gitScm = mock(SCM.class);
@@ -73,7 +74,7 @@ class ScmResolverTest {
     }
 
     @Test
-    void shouldCreateGitBlamerForPipelineWithFlowNode() throws IOException {
+    void shouldResolveScmForPipelineWithFlowNode() throws IOException {
         WorkflowJob pipeline = createPipeline();
         pipeline.setDefinition(createCpsFlowDefinition());
 


### PR DESCRIPTION
Some jobs are using multiple SCM repositories: one for the code, one for the pipeline library, etc. We need a way to select the correct repository for all features of the forensics API. See also [JENKINS-64578](https://issues.jenkins.io/browse/JENKINS-64578).

See downstream PR https://github.com/jenkinsci/git-forensics-plugin/pull/213