### PR TITLE
Make use of branch API to obtain correct reference job.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <url>https://github.com/jenkinsci/forensics-api-plugin</url>
 
   <properties>
-    <revision>0.10.0</revision>
+    <revision>0.9.1</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.forensics.api</module.name>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,10 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
@@ -162,7 +162,7 @@ public abstract class ReferenceRecorder extends SimpleReferenceRecorder {
             else if (target != null) {
                 log.logInfo("Reference job inferred from toplevel project '%s'", topLevel.getDisplayName());
                 log.logInfo("Target branch: '%s'", getReferenceBranch());
-                log.logInfo("Inferred job: '%s'", target);
+                log.logInfo("Inferred job: '%s'", target.getDisplayName());
 
                 return Optional.of(target);
             }

--- a/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
@@ -7,8 +7,6 @@ import org.apache.commons.lang3.StringUtils;
 import edu.hm.hafner.util.FilteredLog;
 
 import org.kohsuke.stapler.DataBoundSetter;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
@@ -154,7 +152,7 @@ public abstract class ReferenceRecorder extends SimpleReferenceRecorder {
         Job<?, ?> job = run.getParent();
         ItemGroup<?> topLevel = job.getParent();
         if (topLevel instanceof MultiBranchProject) {
-            WorkflowJob target = ((WorkflowMultiBranchProject) topLevel).getItemByBranchName(getReferenceBranch());
+            Job<?, ?> target = ((MultiBranchProject<?, ?>) topLevel).getItemByBranchName(getReferenceBranch());
             if (job.equals(target)) {
                 log.logInfo("No reference job required - we are already on the default branch for '%s'",
                         job.getName());


### PR DESCRIPTION
Replace the fragile job name computation based on the branch name: reuse branch API to obtain the correct job for a given branch. See [JENKINS-64544](https://issues.jenkins.io/browse/JENKINS-64544).