### PR TITLE
Fix NPE if SCM key is `null` in old serialization

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -52,6 +53,20 @@ public class RepositoryMinerStep extends Recorder implements SimpleBuildStep {
         super();
 
         // empty constructor required for Stapler
+    }
+
+    /**
+     * Called after de-serialization to retain backward compatibility or to populate new elements (that would be
+     * otherwise initialized to {@code null}).
+     *
+     * @return this
+     */
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification = "Deserialization of instances that do not have all fields yet")
+    protected Object readResolve() {
+        if (scm == null) {
+            scm = StringUtils.EMPTY;
+        }
+        return this;
     }
 
     /**


### PR DESCRIPTION
```
ERROR: Build step failed with exception
java.lang.NullPointerException
	at java.lang.String.contains(String.java:2133)
	at io.jenkins.plugins.forensics.util.ScmResolver.lambda$getScms$0(ScmResolver.java:59)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
	at io.jenkins.plugins.forensics.util.ScmResolver.getScms(ScmResolver.java:60)
	at io.jenkins.plugins.forensics.miner.RepositoryMinerStep.mineRepositories(RepositoryMinerStep.java:82)
	at io.jenkins.plugins.forensics.miner.RepositoryMinerStep.perform(RepositoryMinerStep.java:76)
	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:80)
	at hudson.tasks.BuildStepMonitor$3.perform(BuildStepMonitor.java:45)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:803)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:752)
	at hudson.model.Build$BuildExecution.post2(Build.java:177)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:697)
	at hudson.model.Run.execute(Run.java:1932)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
```