### PR TITLE
Fix the link to the reference build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <url>https://github.com/jenkinsci/forensics-api-plugin</url>
 
   <properties>
-    <revision>1.3.0</revision>
+    <revision>1.2.1</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.forensics.api</module.name>

--- a/src/main/java/io/jenkins/plugins/forensics/miner/CommitStatisticsBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/CommitStatisticsBuildAction.java
@@ -63,9 +63,40 @@ public class CommitStatisticsBuildAction extends InvisibleAction implements Last
         return commitStatistics;
     }
 
+    /**
+     * Returns whether the statistics are based on a reference build or on the previous build.
+     *
+     * @return {@code true} if there is a reference build defined, {@code false} otherwise
+     */
+    public boolean hasReferenceBuild() {
+        ReferenceBuild referenceBuildAction = getOwner().getAction(ReferenceBuild.class);
+        if (referenceBuildAction == null) {
+            return false;
+        }
+        return referenceBuildAction.hasReferenceBuild();
+    }
+
+    /**
+     * Returns the reference build action if present.
+     *
+     * @return the action
+     */
     @CheckForNull
     public ReferenceBuild getReferenceBuild() {
         return getOwner().getAction(ReferenceBuild.class);
+    }
+
+    /**
+     * Returns a link that can be used in Jelly views to navigate to the reference build.
+     *
+     * @return the link
+     */
+    public String getReferenceBuildLink() {
+        ReferenceBuild build = getReferenceBuild();
+        if (build == null) {
+            return ReferenceBuild.NO_REFERENCE_BUILD;
+        }
+        return build.getReferenceLink();
     }
 
     @Override

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/CommitStatisticsBuildAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/CommitStatisticsBuildAction/summary.jelly
@@ -8,10 +8,12 @@
       <li>
         Commits: ${s.commitCount} -
         <j:choose>
-          <j:when test="${it.referenceBuild != null}">
-            compared to target branch of build <j:out value="${it.referenceBuild.referenceLink}"/>
+          <j:when test="${it.hasReferenceBuild()}">
+            compared to target branch build <j:out value="${it.referenceBuildLink}"/>
           </j:when>
+          <j:otherwise>
             compared to previous build
+          </j:otherwise>
         </j:choose>
       </li>
       <li>


### PR DESCRIPTION
If the reference build has been found then both decision paths have been rendered. 