### PR TITLE
Use upper-case for logging statements

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/miner/CommitStatistics.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/CommitStatistics.java
@@ -201,7 +201,7 @@ public class CommitStatistics implements Serializable {
      *         the logger
      */
     public static void logCommits(final List<CommitDiffItem> commits, final FilteredLog logger) {
-        logger.logInfo("-> %d commits analyzed", countCommits(commits));
+        logger.logInfo("-> %d commits with differences analyzed", countCommits(commits));
         logIfPositive(countChanges(commits), "-> %d MODIFY commit diff items", logger);
         logIfPositive(countMoves(commits), "-> %d RENAME commit diff items", logger);
         logIfPositive(countDeletes(commits), "-> %d DELETE commit diff items", logger);

--- a/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceFinder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceFinder.java
@@ -33,11 +33,11 @@ public class ReferenceFinder {
             Optional<Run<?, ?>> referenceBuild = action.getReferenceBuild();
             if (referenceBuild.isPresent()) {
                 Run<?, ?> reference = referenceBuild.get();
-                log.logInfo("-> found '%s'", reference.getFullDisplayName());
+                log.logInfo("-> Found '%s'", reference.getFullDisplayName());
 
                 return Optional.of(reference);
             }
-            log.logInfo("-> no reference build recorded");
+            log.logInfo("-> No reference build recorded");
         }
         return Optional.empty();
     }

--- a/src/test/java/io/jenkins/plugins/forensics/miner/CommitStatisticsTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/miner/CommitStatisticsTest.java
@@ -53,7 +53,7 @@ class CommitStatisticsTest extends SerializableTest<CommitStatistics> {
                 .hasCommitCount(0);
 
         assertThat(logCommits(commits).getInfoMessages()).containsExactly(
-                "-> 0 commits analyzed",
+                "-> 0 commits with differences analyzed",
                 "-> 0 lines added",
                 "-> 0 lines deleted");
 
@@ -73,7 +73,7 @@ class CommitStatisticsTest extends SerializableTest<CommitStatistics> {
                 .hasCommitCount(1);
 
         assertThat(logCommits(commits).getInfoMessages()).containsExactly(
-                "-> 1 commits analyzed",
+                "-> 1 commits with differences analyzed",
                 "-> 1 MODIFY commit diff items",
                 "-> 3 lines added",
                 "-> 2 lines deleted");
@@ -94,7 +94,7 @@ class CommitStatisticsTest extends SerializableTest<CommitStatistics> {
                 .hasCommitCount(2);
 
         assertThat(logCommits(commits).getInfoMessages()).containsExactly(
-                "-> 2 commits analyzed",
+                "-> 2 commits with differences analyzed",
                 "-> 2 MODIFY commit diff items",
                 "-> 6 lines added",
                 "-> 6 lines deleted");
@@ -116,7 +116,7 @@ class CommitStatisticsTest extends SerializableTest<CommitStatistics> {
                 .hasCommitCount(2);
 
         assertThat(logCommits(commits).getInfoMessages()).containsExactly(
-                "-> 2 commits analyzed",
+                "-> 2 commits with differences analyzed",
                 "-> 2 MODIFY commit diff items",
                 "-> 1 DELETE commit diff items",
                 "-> 6 lines added",
@@ -139,7 +139,7 @@ class CommitStatisticsTest extends SerializableTest<CommitStatistics> {
                 .hasCommitCount(3);
 
         assertThat(logCommits(commits).getInfoMessages()).containsExactly(
-                "-> 3 commits analyzed",
+                "-> 3 commits with differences analyzed",
                 "-> 2 MODIFY commit diff items",
                 "-> 1 RENAME commit diff items",
                 "-> 1 DELETE commit diff items",


### PR DESCRIPTION
Make logging output consistent across the different steps.