### PR TITLE
[JENKINS-66672] Obtain target branch from SCM properties

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
@@ -178,6 +178,7 @@ public abstract class ReferenceRecorder extends SimpleReferenceRecorder {
         return discoverJobFromMultiBranchPipeline(run, log);
     }
 
+    @SuppressWarnings("rawtypes")
     private Optional<Job<?, ?>> discoverJobFromMultiBranchPipeline(final Run<?, ?> run, final FilteredLog log) {
         Job<?, ?> job = run.getParent();
         ItemGroup<?> topLevel = job.getParent();
@@ -211,6 +212,7 @@ public abstract class ReferenceRecorder extends SimpleReferenceRecorder {
         return Optional.empty();
     }
 
+    @SuppressWarnings("rawtypes")
     private Optional<? extends Job> findPrimaryBranch(final ItemGroup<?> topLevel) {
         return topLevel.getAllItems().stream()
                 .map(Item::getAllJobs)


### PR DESCRIPTION
For multi branch pipelines the target branch typically is configured in the SCM properties. Either in the properties of the pull request (`ChangeRequestSCMHead`) or in the properties of the Jenkins jobs (`PrimaryInstanceMetadataAction `). 