### PR TITLE
Add a new detail view that shows info and error messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
     <plugin-util-api.version>2.5.1</plugin-util-api.version>
     <data-tables-api.version>1.11.3-4</data-tables-api.version>
     <jquery3-api.version>3.6.0-2</jquery3-api.version>
-    <font-awesome-api.version>5.15.4-2</font-awesome-api.version>
+    <font-awesome-api.version>5.15.4-3</font-awesome-api.version>
+    <bootstrap5-api.version>5.1.3-3</bootstrap5-api.version>
     <echarts-api.version>5.2.2-1</echarts-api.version>
-    <bootstrap5-api.version>5.1.3-2</bootstrap5-api.version>
 
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <jquery3-api.version>3.6.0-2</jquery3-api.version>
     <font-awesome-api.version> 5.15.4-1</font-awesome-api.version>
     <echarts-api.version>5.2.2-1</echarts-api.version>
-    <bootstrap5-api.version>5.1.3-2-rc180.ef7d9888e7d1</bootstrap5-api.version>
+    <bootstrap5-api.version>5.1.3-2</bootstrap5-api.version>
 
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <plugin-util-api.version>2.5.1</plugin-util-api.version>
     <data-tables-api.version>1.11.3-4</data-tables-api.version>
     <jquery3-api.version>3.6.0-2</jquery3-api.version>
-    <font-awesome-api.version> 5.15.4-1</font-awesome-api.version>
+    <font-awesome-api.version>5.15.4-2</font-awesome-api.version>
     <echarts-api.version>5.2.2-1</echarts-api.version>
     <bootstrap5-api.version>5.1.3-2</bootstrap5-api.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <jquery3-api.version>3.6.0-2</jquery3-api.version>
     <font-awesome-api.version> 5.15.4-1</font-awesome-api.version>
     <echarts-api.version>5.2.2-1</echarts-api.version>
-    <bootstrap5-api.version>5.1.3-1</bootstrap5-api.version>
+    <bootstrap5-api.version>5.1.3-2-rc180.ef7d9888e7d1</bootstrap5-api.version>
 
   </properties>
 

--- a/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceBuild.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceBuild.java
@@ -10,9 +10,11 @@ import org.apache.commons.lang3.StringUtils;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import org.kohsuke.stapler.StaplerProxy;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
 
+import io.jenkins.plugins.bootstrap5.MessagesViewModel;
 import io.jenkins.plugins.util.JenkinsFacade;
 
 import static j2html.TagCreator.*;
@@ -24,7 +26,7 @@ import static j2html.TagCreator.*;
  * @author Ullrich Hafner
  * @see ReferenceRecorder
  */
-public class ReferenceBuild implements RunAction2, Serializable {
+public class ReferenceBuild implements RunAction2, Serializable, StaplerProxy {
     private static final long serialVersionUID = -4549516129641755356L;
 
     /**
@@ -32,6 +34,8 @@ public class ReferenceBuild implements RunAction2, Serializable {
      * initially but has been deleted afterwards.
      */
     public static final String NO_REFERENCE_BUILD = "-";
+
+    static final String REFERENCE_DETAILS_URL = "reference";
 
     /**
      * Returns a link that can be used in Jelly views to navigate to the reference build.
@@ -182,6 +186,16 @@ public class ReferenceBuild implements RunAction2, Serializable {
 
     @Override
     public String getUrlName() {
-        return null;
+        return REFERENCE_DETAILS_URL;
+    }
+
+    /**
+     * Returns the detail view for the messages captured during the computation of the reference build.
+     *
+     * @return the detail view for the messages
+     */
+    @Override
+    public Object getTarget() {
+        return new MessagesViewModel(getOwner(), Messages.Messages_DisplayName(), messages);
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceRecorder.java
@@ -108,6 +108,7 @@ public abstract class ReferenceRecorder extends SimpleReferenceRecorder {
      * @param targetBranch
      *         the name of the default branch
      */
+    @DataBoundSetter
     public void setTargetBranch(final String targetBranch) {
         this.defaultBranch = StringUtils.stripToEmpty(targetBranch);
     }

--- a/src/main/resources/io/jenkins/plugins/forensics/reference/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/forensics/reference/Messages.properties
@@ -1,2 +1,3 @@
 Recorder.DisplayName=Discover reference build
+Messages.DisplayName=Reference build
 FieldValidator.Error.ReferenceJobDoesNotExist=There is no such job - maybe the job has been renamed?

--- a/src/main/resources/io/jenkins/plugins/forensics/reference/ReferenceBuild/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/reference/ReferenceBuild/summary.jelly
@@ -6,18 +6,14 @@
       <j:choose>
         <j:when test="${it.hasReferenceBuild()}">
           ${%reference.found}
-          <a id="reference-info" href="reference">
-            <fa:svg-icon name="info-circle" class="info-page-decorator" tooltip="${%messages.tooltip}"/>
-          </a>
+          <fa:image-button label="${%Open log messages}" name="info-circle" tooltip="${%icon.info.tooltip}" url="reference" />
           <ul>
             <li><j:out value="${it.referenceLink}"/></li>
           </ul>
         </j:when>
         <j:otherwise>
           ${%reference.notFound}
-          <a id="reference-info" href="reference">
-            <fa:svg-icon name="exclamation-triangle" class="info-page-decorator" tooltip="${%messages.tooltip}"/>
-          </a>
+          <fa:image-button label="${%Open error messages}" name="exclamation-triangle" tooltip="${%icon.error.tooltip}" url="reference" class="fa-image-button-warning"/>
         </j:otherwise>
 
       </j:choose>

--- a/src/main/resources/io/jenkins/plugins/forensics/reference/ReferenceBuild/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/reference/ReferenceBuild/summary.jelly
@@ -1,25 +1,23 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson"  xmlns:fa="/font-awesome">
 
   <t:summary icon="/plugin/forensics-api/icons/crosshair.svg">
 
       <j:choose>
         <j:when test="${it.hasReferenceBuild()}">
-          ${%Reference.Build.Found}
+          ${%reference.found}
+          <a id="reference-info" href="reference">
+            <fa:svg-icon name="info-circle" class="info-page-decorator" tooltip="${%messages.tooltip}"/>
+          </a>
           <ul>
             <li><j:out value="${it.referenceLink}"/></li>
-            <j:forEach var="message" items="${it.messages}">
-              <li>${message}</li>
-            </j:forEach>
           </ul>
         </j:when>
         <j:otherwise>
-          ${%No.Reference.Build}
-          <ul>
-            <j:forEach var="message" items="${it.messages}">
-                <li>${message}</li>
-            </j:forEach>
-          </ul>
+          ${%reference.notFound}
+          <a id="reference-info" href="reference">
+            <fa:svg-icon name="exclamation-triangle" class="info-page-decorator" tooltip="${%messages.tooltip}"/>
+          </a>
         </j:otherwise>
 
       </j:choose>

--- a/src/main/resources/io/jenkins/plugins/forensics/reference/ReferenceBuild/summary.properties
+++ b/src/main/resources/io/jenkins/plugins/forensics/reference/ReferenceBuild/summary.properties
@@ -1,3 +1,4 @@
 reference.found=Reference build for delta reports
 reference.notFound=No reference build found
-messages.tooltip=Reference build for delta reports
+icon.error.tooltip=Some errors have been logged while searching for the reference build, click to see these errors in a details view.
+icon.info.tooltip=Click to see all logging messages while searching for the reference build.

--- a/src/main/resources/io/jenkins/plugins/forensics/reference/ReferenceBuild/summary.properties
+++ b/src/main/resources/io/jenkins/plugins/forensics/reference/ReferenceBuild/summary.properties
@@ -1,2 +1,3 @@
-Reference.Build.Found=Reference build for delta reports
-No.Reference.Build=No reference build found
+reference.found=Reference build for delta reports
+reference.notFound=No reference build found
+messages.tooltip=Reference build for delta reports

--- a/src/test/java/io/jenkins/plugins/forensics/reference/ReferenceBuildTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/reference/ReferenceBuildTest.java
@@ -32,7 +32,6 @@ class ReferenceBuildTest {
         Run<?, ?> newBuild = mock(Run.class);
         referenceBuild.onAttached(newBuild);
         assertThat(referenceBuild).hasOwner(newBuild);
-
         referenceBuild.onLoad(currentBuild);
         assertThat(referenceBuild).hasOwner(currentBuild);
     }
@@ -52,7 +51,7 @@ class ReferenceBuildTest {
 
         assertThat(referenceBuild.getIconFileName()).isNull();
         assertThat(referenceBuild.getDisplayName()).isNull();
-        assertThat(referenceBuild.getUrlName()).isNull();
+        assertThat(referenceBuild.getUrlName()).isEqualTo(ReferenceBuild.REFERENCE_DETAILS_URL);
     }
 
     @Test
@@ -70,7 +69,7 @@ class ReferenceBuildTest {
 
         assertThat(referenceBuild.getIconFileName()).isNull();
         assertThat(referenceBuild.getDisplayName()).isNull();
-        assertThat(referenceBuild.getUrlName()).isNull();
+        assertThat(referenceBuild.getUrlName()).isEqualTo(ReferenceBuild.REFERENCE_DETAILS_URL);
     }
 
     @Test
@@ -94,7 +93,6 @@ class ReferenceBuildTest {
 
         assertThat(referenceBuild.getIconFileName()).isNull();
         assertThat(referenceBuild.getDisplayName()).isNull();
-        assertThat(referenceBuild.getUrlName()).isNull();
+        assertThat(referenceBuild.getUrlName()).isEqualTo(ReferenceBuild.REFERENCE_DETAILS_URL);
     }
-
 }

--- a/src/test/java/io/jenkins/plugins/forensics/reference/ReferenceBuildTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/reference/ReferenceBuildTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import hudson.model.Run;
 
+import io.jenkins.plugins.bootstrap5.MessagesViewModel;
 import io.jenkins.plugins.util.JenkinsFacade;
 
 import static io.jenkins.plugins.forensics.assertions.Assertions.*;
@@ -46,12 +47,20 @@ class ReferenceBuildTest {
         assertThat(referenceBuild).hasOnlyMessages(MESSAGES);
         assertThat(referenceBuild).hasOwner(currentBuild);
         assertThat(referenceBuild).hasReferenceBuildId(ReferenceBuild.NO_REFERENCE_BUILD);
-        assertThat(referenceBuild).hasReferenceLink("Reference build '-' not found anymore - maybe the build has been renamed or deleted?");
+        assertThat(referenceBuild).hasReferenceLink(
+                "Reference build '-' not found anymore - maybe the build has been renamed or deleted?");
         assertThat(referenceBuild.getReferenceBuild()).isEmpty();
 
         assertThat(referenceBuild.getIconFileName()).isNull();
         assertThat(referenceBuild.getDisplayName()).isNull();
         assertThat(referenceBuild.getUrlName()).isEqualTo(ReferenceBuild.REFERENCE_DETAILS_URL);
+
+        assertThat(referenceBuild.getTarget()).isInstanceOfSatisfying(MessagesViewModel.class,
+                model -> {
+                    assertThat(model.getDisplayName()).isEqualTo("Reference build - Messages");
+                    assertThat(model.getErrorMessages()).isEmpty();
+                    assertThat(model.getInfoMessages()).containsAll(MESSAGES);
+                });
     }
 
     @Test


### PR DESCRIPTION
This view has been copied from the warnings-ng plugin and is now available for all plugins that want to show information and error messages. This is a downstream PR for jenkinsci/bootstrap5-api-plugin#65.
