### PR TITLE
Add Code Difference API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <url>https://github.com/jenkinsci/forensics-api-plugin</url>
 
   <properties>
-    <revision>1.8.0</revision>
+    <revision>1.9.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.forensics.api</module.name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <url>https://github.com/jenkinsci/forensics-api-plugin</url>
 
   <properties>
-    <revision>1.9.0</revision>
+    <revision>1.8.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.forensics.api</module.name>

--- a/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculator.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculator.java
@@ -1,10 +1,11 @@
 package io.jenkins.plugins.forensics.delta;
 
-import edu.hm.hafner.util.FilteredLog;
-import io.jenkins.plugins.forensics.delta.model.Delta;
-
 import java.io.Serializable;
 import java.util.Optional;
+
+import edu.hm.hafner.util.FilteredLog;
+
+import io.jenkins.plugins.forensics.delta.model.Delta;
 
 /**
  * Calculates the code difference - so called 'delta' - between two commits.
@@ -18,12 +19,17 @@ public abstract class DeltaCalculator implements Serializable {
     /**
      * Calculates the {@link Delta} between two passed commits.
      *
-     * @param currentCommitId   The currently processed commit ID
-     * @param referenceCommitId The reference commit ID
-     * @param logger            The used log
+     * @param currentCommitId
+     *         The currently processed commit ID
+     * @param referenceCommitId
+     *         The reference commit ID
+     * @param logger
+     *         The used log
+     *
      * @return the delta if it could be calculated
      */
-    public abstract Optional<Delta> calculateDelta(String currentCommitId, String referenceCommitId, FilteredLog logger);
+    public abstract Optional<Delta> calculateDelta(String currentCommitId, String referenceCommitId,
+            FilteredLog logger);
 
     /**
      * A delta calculator that does nothing.
@@ -34,7 +40,7 @@ public abstract class DeltaCalculator implements Serializable {
 
         @Override
         public Optional<Delta> calculateDelta(final String currentCommitId, final String referenceCommitId,
-                                              final FilteredLog logger) {
+                final FilteredLog logger) {
             return Optional.empty();
         }
     }

--- a/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculator.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculator.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.forensics.delta;
+
+import edu.hm.hafner.util.FilteredLog;
+import io.jenkins.plugins.forensics.delta.model.Delta;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * Calculates the code difference - so called 'delta' - between two commits.
+ *
+ * @author Florian Orendi
+ */
+public abstract class DeltaCalculator implements Serializable {
+
+    private static final long serialVersionUID = 8641535877389921937L;
+
+    /**
+     * Calculates the {@link Delta} between two passed commits.
+     *
+     * @param currentCommitId
+     *         The currently processed commit ID
+     * @param referenceCommitId
+     *         The reference commit ID
+     * @param logger
+     *         The used log
+     *
+     * @return the delta if it could be calculated
+     */
+    public abstract Optional<Delta> calculateDelta(final String currentCommitId, final String referenceCommitId,
+            final FilteredLog logger);
+
+    /**
+     * A delta calculator that does nothing.
+     */
+    public static class NullDeltaCalculator extends DeltaCalculator {
+
+        private static final long serialVersionUID = 1564285974889709821L;
+
+        @Override
+        public Optional<Delta> calculateDelta(final String currentCommitId, final String referenceCommitId,
+                                              final FilteredLog logger) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculator.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculator.java
@@ -18,17 +18,12 @@ public abstract class DeltaCalculator implements Serializable {
     /**
      * Calculates the {@link Delta} between two passed commits.
      *
-     * @param currentCommitId
-     *         The currently processed commit ID
-     * @param referenceCommitId
-     *         The reference commit ID
-     * @param logger
-     *         The used log
-     *
+     * @param currentCommitId   The currently processed commit ID
+     * @param referenceCommitId The reference commit ID
+     * @param logger            The used log
      * @return the delta if it could be calculated
      */
-    public abstract Optional<Delta> calculateDelta(final String currentCommitId, final String referenceCommitId,
-            final FilteredLog logger);
+    public abstract Optional<Delta> calculateDelta(String currentCommitId, String referenceCommitId, FilteredLog logger);
 
     /**
      * A delta calculator that does nothing.

--- a/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactory.java
@@ -64,7 +64,7 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
             logger.logInfo("-> no SCMs found to be processed");
             return new NullDeltaCalculator();
         }
-        return findAllExtensions().stream()
+        return findAllDeltaCalculatorFactoryInstances().stream()
                 .map(deltaCalculatorFactory -> deltaCalculatorFactory.createDeltaCalculator(scms.iterator().next(), run,
                         workTree, listener, logger))
                 .flatMap(OPTIONAL_MAPPER)
@@ -85,7 +85,7 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     private static Optional<DeltaCalculator> findDeltaCalculator(final Run<?, ?> run, final FilePath workTree,
                                                                  final TaskListener listener, final FilteredLog logger) {
         SCM scm = new ScmResolver().getScm(run);
-        return findAllExtensions().stream()
+        return findAllDeltaCalculatorFactoryInstances().stream()
                 .map(deltaCalculatorFactory -> deltaCalculatorFactory.createDeltaCalculator(scm, run, workTree,
                         listener, logger))
                 .flatMap(OPTIONAL_MAPPER)
@@ -99,11 +99,12 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
      * @return the created delta calculator instance
      */
     private static DeltaCalculator createNullDeltaCalculator(final FilteredLog logger) {
-        if (findAllExtensions().isEmpty()) {
+        if (findAllDeltaCalculatorFactoryInstances().isEmpty()) {
             logger.logInfo(
                     "-> No delta calculator installed yet. "
                             + "You need to install the 'git-forensics' plugin to enable it for Git.");
-        } else {
+        }
+        else {
             logger.logInfo("-> No suitable delta calculator found.");
         }
         return new NullDeltaCalculator();
@@ -114,7 +115,7 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
      *
      * @return all found extensions
      */
-    private static List<DeltaCalculatorFactory> findAllExtensions() {
+    private static List<DeltaCalculatorFactory> findAllDeltaCalculatorFactoryInstances() {
         return new JenkinsFacade().getExtensionsFor(DeltaCalculatorFactory.class);
     }
 

--- a/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactory.java
@@ -1,20 +1,22 @@
 package io.jenkins.plugins.forensics.delta;
 
-import edu.hm.hafner.util.FilteredLog;
-import hudson.ExtensionPoint;
-import hudson.FilePath;
-import hudson.model.Run;
-import hudson.model.TaskListener;
-import hudson.scm.SCM;
-import io.jenkins.plugins.forensics.delta.DeltaCalculator.NullDeltaCalculator;
-import io.jenkins.plugins.forensics.util.ScmResolver;
-import io.jenkins.plugins.util.JenkinsFacade;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import edu.hm.hafner.util.FilteredLog;
+
+import hudson.ExtensionPoint;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.SCM;
+
+import io.jenkins.plugins.forensics.delta.DeltaCalculator.NullDeltaCalculator;
+import io.jenkins.plugins.forensics.util.ScmResolver;
+import io.jenkins.plugins.util.JenkinsFacade;
 
 /**
  * Jenkins extension point that allows plugins to create {@link DeltaCalculator} instances based on a supported {@link
@@ -30,15 +32,20 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Returns a {@link DeltaCalculator} for the specified {@link Run build}.
      *
-     * @param run            the current build
-     * @param scmDirectories paths to search for the SCM repository
-     * @param listener       a task listener
-     * @param logger         a logger to report error messages
+     * @param run
+     *         the current build
+     * @param scmDirectories
+     *         paths to search for the SCM repository
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
      * @return a delta calculator for the SCM of the specified build or a {@link NullDeltaCalculator} if the SCM is not
-     * supported
+     *         supported
      */
     public static DeltaCalculator findDeltaCalculator(final Run<?, ?> run,
-                                                      final Collection<FilePath> scmDirectories, final TaskListener listener, final FilteredLog logger) {
+            final Collection<FilePath> scmDirectories, final TaskListener listener, final FilteredLog logger) {
         return scmDirectories.stream()
                 .map(directory -> findDeltaCalculator(run, directory, listener, logger))
                 .flatMap(OPTIONAL_MAPPER)
@@ -49,16 +56,22 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Returns a {@link DeltaCalculator} for the specified {@link SCM repository}.
      *
-     * @param scm      the key of the SCM repository (substring that must be part of the SCM key)
-     * @param run      the current build
-     * @param workTree the working tree of the repository
-     * @param listener a task listener
-     * @param logger   a logger to report error messages
+     * @param scm
+     *         the key of the SCM repository (substring that must be part of the SCM key)
+     * @param run
+     *         the current build
+     * @param workTree
+     *         the working tree of the repository
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
      * @return a delta calculator for the SCM of the specified build or a {@link NullDeltaCalculator} if the SCM is not
-     * supported
+     *         supported
      */
     public static DeltaCalculator findDeltaCalculator(final String scm, final Run<?, ?> run,
-                                                      final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
+            final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
         Collection<? extends SCM> scms = new ScmResolver().getScms(run, scm);
         if (scms.isEmpty()) {
             logger.logInfo("-> no SCMs found to be processed");
@@ -75,15 +88,20 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Returns a {@link DeltaCalculator} for the specified {@link Run build} and {@link FilePath}.
      *
-     * @param run      the current build
-     * @param workTree the working tree of the repository
-     * @param listener a task listener
-     * @param logger   a logger to report error messages
+     * @param run
+     *         the current build
+     * @param workTree
+     *         the working tree of the repository
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
      * @return a delta calculator for the SCM of the specified build or a {@link NullDeltaCalculator} if the SCM is not
-     * supported
+     *         supported
      */
     private static Optional<DeltaCalculator> findDeltaCalculator(final Run<?, ?> run, final FilePath workTree,
-                                                                 final TaskListener listener, final FilteredLog logger) {
+            final TaskListener listener, final FilteredLog logger) {
         SCM scm = new ScmResolver().getScm(run);
         return findAllDeltaCalculatorFactoryInstances().stream()
                 .map(deltaCalculatorFactory -> deltaCalculatorFactory.createDeltaCalculator(scm, run, workTree,
@@ -95,7 +113,9 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Creates a {@link NullDeltaCalculator} that can be used if no installed delta calculator has been found.
      *
-     * @param logger The log
+     * @param logger
+     *         The log
+     *
      * @return the created delta calculator instance
      */
     private static DeltaCalculator createNullDeltaCalculator(final FilteredLog logger) {
@@ -122,13 +142,19 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Returns a {@link DeltaCalculator} for the specified {@link SCM}.
      *
-     * @param scm       the {@link SCM} to create the delta calculator for
-     * @param run       the current build
-     * @param workspace the workspace of the current build
-     * @param listener  a task listener
-     * @param logger    a logger to report error messages
+     * @param scm
+     *         the {@link SCM} to create the delta calculator for
+     * @param run
+     *         the current build
+     * @param workspace
+     *         the workspace of the current build
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
      * @return a matching delta calculator instance
      */
     public abstract Optional<DeltaCalculator> createDeltaCalculator(SCM scm, Run<?, ?> run, FilePath workspace,
-                                                                    TaskListener listener, FilteredLog logger);
+            TaskListener listener, FilteredLog logger);
 }

--- a/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactory.java
@@ -1,0 +1,158 @@
+package io.jenkins.plugins.forensics.delta;
+
+import edu.hm.hafner.util.FilteredLog;
+import hudson.ExtensionPoint;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.SCM;
+import io.jenkins.plugins.forensics.delta.DeltaCalculator.NullDeltaCalculator;
+import io.jenkins.plugins.forensics.util.ScmResolver;
+import io.jenkins.plugins.util.JenkinsFacade;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Jenkins extension point that allows plugins to create {@link DeltaCalculator} instances based on a supported {@link
+ * SCM}.
+ *
+ * @author Florian Orendi
+ */
+public abstract class DeltaCalculatorFactory implements ExtensionPoint {
+
+    private static final Function<Optional<DeltaCalculator>, Stream<? extends DeltaCalculator>> OPTIONAL_MAPPER
+            = o -> o.map(Stream::of).orElseGet(Stream::empty);
+
+    /**
+     * Returns a {@link DeltaCalculator} for the specified {@link Run build}.
+     *
+     * @param run
+     *         the current build
+     * @param scmDirectories
+     *         paths to search for the SCM repository
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
+     * @return a delta calculator for the SCM of the specified build or a {@link NullDeltaCalculator} if the SCM is not
+     *         supported
+     */
+    public static DeltaCalculator findDeltaCalculator(final Run<?, ?> run,
+            final Collection<FilePath> scmDirectories, final TaskListener listener, final FilteredLog logger) {
+        return scmDirectories.stream()
+                .map(directory -> findDeltaCalculator(run, directory, listener, logger))
+                .flatMap(OPTIONAL_MAPPER)
+                .findFirst()
+                .orElseGet(() -> createNullDeltaCalculator(logger));
+    }
+
+    /**
+     * Returns a {@link DeltaCalculator} for the specified {@link SCM repository}.
+     *
+     * @param scm
+     *         the key of the SCM repository (substring that must be part of the SCM key)
+     * @param run
+     *         the current build
+     * @param workTree
+     *         the working tree of the repository
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
+     * @return a delta calculator for the SCM of the specified build or a {@link NullDeltaCalculator} if the SCM is not
+     *         supported
+     */
+    public static DeltaCalculator findDeltaCalculator(final String scm, final Run<?, ?> run,
+            final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
+        Collection<? extends SCM> scms = new ScmResolver().getScms(run, scm);
+        if (scms.isEmpty()) {
+            logger.logInfo("-> no SCM found");
+            return new NullDeltaCalculator();
+        }
+        return findAllExtensions().stream()
+                .map(deltaCalculatorFactory -> deltaCalculatorFactory.createDeltaCalculator(scms.iterator().next(), run,
+                        workTree, listener, logger))
+                .flatMap(OPTIONAL_MAPPER)
+                .findFirst()
+                .orElseGet(() -> createNullDeltaCalculator(logger));
+    }
+
+    /**
+     * Returns a {@link DeltaCalculator} for the specified {@link Run build} and {@link FilePath}.
+     *
+     * @param run
+     *         the current build
+     * @param workTree
+     *         the working tree of the repository
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
+     * @return a delta calculator for the SCM of the specified build or a {@link NullDeltaCalculator} if the SCM is not
+     *         supported
+     */
+    private static Optional<DeltaCalculator> findDeltaCalculator(final Run<?, ?> run, final FilePath workTree,
+            final TaskListener listener, final FilteredLog logger) {
+        SCM scm = new ScmResolver().getScm(run);
+        return findAllExtensions().stream()
+                .map(deltaCalculatorFactory -> deltaCalculatorFactory.createDeltaCalculator(scm, run, workTree,
+                        listener, logger))
+                .flatMap(OPTIONAL_MAPPER)
+                .findFirst();
+    }
+
+    /**
+     * Creates a {@link NullDeltaCalculator} that can be used if no installed delta calculator has been found.
+     *
+     * @param logger
+     *         The log
+     *
+     * @return the created delta calculator instance
+     */
+    private static DeltaCalculator createNullDeltaCalculator(final FilteredLog logger) {
+        if (findAllExtensions().isEmpty()) {
+            logger.logInfo(
+                    "-> No delta calculator installed yet. " +
+                            "You need to install the 'git-forensics' plugin to enable it for Git.");
+        }
+        else {
+            logger.logInfo("-> No suitable delta calculator found.");
+        }
+        return new NullDeltaCalculator();
+    }
+
+    /**
+     * Searches for all installed Jenkins extensions for {@link DeltaCalculatorFactory}.
+     *
+     * @return all found extensions
+     */
+    private static List<DeltaCalculatorFactory> findAllExtensions() {
+        return new JenkinsFacade().getExtensionsFor(DeltaCalculatorFactory.class);
+    }
+
+    /**
+     * Returns a {@link DeltaCalculator} for the specified {@link SCM}.
+     *
+     * @param scm
+     *         the {@link SCM} to create the delta calculator for
+     * @param run
+     *         the current build
+     * @param workspace
+     *         the workspace of the current build
+     * @param listener
+     *         a task listener
+     * @param logger
+     *         a logger to report error messages
+     *
+     * @return a matching delta calculator instance
+     */
+    public abstract Optional<DeltaCalculator> createDeltaCalculator(SCM scm, Run<?, ?> run, FilePath workspace,
+            TaskListener listener, FilteredLog logger);
+}

--- a/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactory.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactory.java
@@ -30,20 +30,15 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Returns a {@link DeltaCalculator} for the specified {@link Run build}.
      *
-     * @param run
-     *         the current build
-     * @param scmDirectories
-     *         paths to search for the SCM repository
-     * @param listener
-     *         a task listener
-     * @param logger
-     *         a logger to report error messages
-     *
+     * @param run            the current build
+     * @param scmDirectories paths to search for the SCM repository
+     * @param listener       a task listener
+     * @param logger         a logger to report error messages
      * @return a delta calculator for the SCM of the specified build or a {@link NullDeltaCalculator} if the SCM is not
-     *         supported
+     * supported
      */
     public static DeltaCalculator findDeltaCalculator(final Run<?, ?> run,
-            final Collection<FilePath> scmDirectories, final TaskListener listener, final FilteredLog logger) {
+                                                      final Collection<FilePath> scmDirectories, final TaskListener listener, final FilteredLog logger) {
         return scmDirectories.stream()
                 .map(directory -> findDeltaCalculator(run, directory, listener, logger))
                 .flatMap(OPTIONAL_MAPPER)
@@ -54,25 +49,19 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Returns a {@link DeltaCalculator} for the specified {@link SCM repository}.
      *
-     * @param scm
-     *         the key of the SCM repository (substring that must be part of the SCM key)
-     * @param run
-     *         the current build
-     * @param workTree
-     *         the working tree of the repository
-     * @param listener
-     *         a task listener
-     * @param logger
-     *         a logger to report error messages
-     *
+     * @param scm      the key of the SCM repository (substring that must be part of the SCM key)
+     * @param run      the current build
+     * @param workTree the working tree of the repository
+     * @param listener a task listener
+     * @param logger   a logger to report error messages
      * @return a delta calculator for the SCM of the specified build or a {@link NullDeltaCalculator} if the SCM is not
-     *         supported
+     * supported
      */
     public static DeltaCalculator findDeltaCalculator(final String scm, final Run<?, ?> run,
-            final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
+                                                      final FilePath workTree, final TaskListener listener, final FilteredLog logger) {
         Collection<? extends SCM> scms = new ScmResolver().getScms(run, scm);
         if (scms.isEmpty()) {
-            logger.logInfo("-> no SCM found");
+            logger.logInfo("-> no SCMs found to be processed");
             return new NullDeltaCalculator();
         }
         return findAllExtensions().stream()
@@ -86,20 +75,15 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Returns a {@link DeltaCalculator} for the specified {@link Run build} and {@link FilePath}.
      *
-     * @param run
-     *         the current build
-     * @param workTree
-     *         the working tree of the repository
-     * @param listener
-     *         a task listener
-     * @param logger
-     *         a logger to report error messages
-     *
+     * @param run      the current build
+     * @param workTree the working tree of the repository
+     * @param listener a task listener
+     * @param logger   a logger to report error messages
      * @return a delta calculator for the SCM of the specified build or a {@link NullDeltaCalculator} if the SCM is not
-     *         supported
+     * supported
      */
     private static Optional<DeltaCalculator> findDeltaCalculator(final Run<?, ?> run, final FilePath workTree,
-            final TaskListener listener, final FilteredLog logger) {
+                                                                 final TaskListener listener, final FilteredLog logger) {
         SCM scm = new ScmResolver().getScm(run);
         return findAllExtensions().stream()
                 .map(deltaCalculatorFactory -> deltaCalculatorFactory.createDeltaCalculator(scm, run, workTree,
@@ -111,18 +95,15 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Creates a {@link NullDeltaCalculator} that can be used if no installed delta calculator has been found.
      *
-     * @param logger
-     *         The log
-     *
+     * @param logger The log
      * @return the created delta calculator instance
      */
     private static DeltaCalculator createNullDeltaCalculator(final FilteredLog logger) {
         if (findAllExtensions().isEmpty()) {
             logger.logInfo(
-                    "-> No delta calculator installed yet. " +
-                            "You need to install the 'git-forensics' plugin to enable it for Git.");
-        }
-        else {
+                    "-> No delta calculator installed yet. "
+                            + "You need to install the 'git-forensics' plugin to enable it for Git.");
+        } else {
             logger.logInfo("-> No suitable delta calculator found.");
         }
         return new NullDeltaCalculator();
@@ -140,19 +121,13 @@ public abstract class DeltaCalculatorFactory implements ExtensionPoint {
     /**
      * Returns a {@link DeltaCalculator} for the specified {@link SCM}.
      *
-     * @param scm
-     *         the {@link SCM} to create the delta calculator for
-     * @param run
-     *         the current build
-     * @param workspace
-     *         the workspace of the current build
-     * @param listener
-     *         a task listener
-     * @param logger
-     *         a logger to report error messages
-     *
+     * @param scm       the {@link SCM} to create the delta calculator for
+     * @param run       the current build
+     * @param workspace the workspace of the current build
+     * @param listener  a task listener
+     * @param logger    a logger to report error messages
      * @return a matching delta calculator instance
      */
     public abstract Optional<DeltaCalculator> createDeltaCalculator(SCM scm, Run<?, ?> run, FilePath workspace,
-            TaskListener listener, FilteredLog logger);
+                                                                    TaskListener listener, FilteredLog logger);
 }

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -6,9 +6,9 @@ import java.util.Objects;
 /**
  * A change made on specific lines within a specific file.
  * <p>
- * The lines are defined by a starting and an ending point (1-based line counter), describing the made changes
- * within the new version of the file. In case of a deleted file, the line range describes the deleted lines within the
- * old version of the file, since only then it is possible to determine what has been deleted.
+ * The lines are defined by a starting and an ending point (1-based line counter), describing the made changes within
+ * the new version of the file. In case of a deleted file, the line range describes the deleted lines within the old
+ * version of the file, since only then it is possible to determine what has been deleted.
  *
  * @author Florian Orendi
  */
@@ -17,9 +17,6 @@ public class Change implements Serializable {
 
     private static final long serialVersionUID = 1543635877389921937L;
 
-    /**
-     * The {@link ChangeEditType} of the change.
-     */
     private final ChangeEditType changeEditType;
 
     /**
@@ -34,9 +31,12 @@ public class Change implements Serializable {
     /**
      * Constructor for an instance which wraps a specific change within a file.
      *
-     * @param changeEditType The type of the change
-     * @param fromLine       The starting line
-     * @param toLine         The ending line
+     * @param changeEditType
+     *         The type of the change
+     * @param fromLine
+     *         The starting line
+     * @param toLine
+     *         The ending line
      */
     public Change(final ChangeEditType changeEditType, final int fromLine, final int toLine) {
         this.changeEditType = changeEditType;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 /**
  * A change made on specific lines within a specific file.
- * <p>
+ *
  * The lines are defined by a starting and an ending point (1-based line counter), describing the made changes within
  * the new version of the file. In case of a deleted file, the line range describes the deleted lines within the old
  * version of the file, since only then it is possible to determine what has been deleted.

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -1,0 +1,49 @@
+package io.jenkins.plugins.forensics.delta.model;
+
+import java.io.Serializable;
+
+/**
+ * A change made on specific lines within a specific file.
+ * <p>
+ * The lines are defined by a starting and an ending point (1-based line counter), describing the made changes
+ * within the new version of the file. In case of a deleted file, the line range describes the deleted lines within the
+ * old version of the file, since only then it is possible to determine what has been deleted.
+ *
+ * @author Florian Orendi
+ */
+public class Change implements Serializable {
+
+    private static final long serialVersionUID = 1543635877389921937L;
+
+    /**
+     * The {@link ChangeEditType} of the change.
+     */
+    private final ChangeEditType changeEditType;
+
+    /**
+     * The starting point of the change (1-based).
+     */
+    private final int fromLine;
+    /**
+     * The ending point of the change (1-based).
+     */
+    private final int toLine;
+
+    public Change(final ChangeEditType changeEditType, final int fromLine, final int toLine) {
+        this.changeEditType = changeEditType;
+        this.fromLine = fromLine;
+        this.toLine = toLine;
+    }
+
+    public ChangeEditType getEditType() {
+        return changeEditType;
+    }
+
+    public int getFromLine() {
+        return fromLine;
+    }
+
+    public int getToLine() {
+        return toLine;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -29,6 +29,13 @@ public class Change implements Serializable {
      */
     private final int toLine;
 
+    /**
+     * Constructor for an instance which wraps a specific change within a file.
+     *
+     * @param changeEditType The type of the change
+     * @param fromLine       The starting line
+     * @param toLine         The ending line
+     */
     public Change(final ChangeEditType changeEditType, final int fromLine, final int toLine) {
         this.changeEditType = changeEditType;
         this.fromLine = fromLine;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.forensics.delta.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * A change made on specific lines within a specific file.
@@ -52,5 +53,24 @@ public class Change implements Serializable {
 
     public int getToLine() {
         return toLine;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Change change = (Change) o;
+        return fromLine == change.fromLine
+                && toLine == change.toLine
+                && changeEditType == change.changeEditType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(changeEditType, fromLine, toLine);
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -12,6 +12,7 @@ import java.util.Objects;
  *
  * @author Florian Orendi
  */
+@SuppressWarnings("PMD.DataClass")
 public class Change implements Serializable {
 
     private static final long serialVersionUID = 1543635877389921937L;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 /**
  * A change made on specific lines within a specific file.
  *
- * The lines are defined by a starting and an ending point (1-based line counter), describing the made changes within
+ * <p>The lines are defined by a starting and an ending point (1-based line counter), describing the made changes within
  * the new version of the file. In case of a deleted file, the line range describes the deleted lines within the old
  * version of the file, since only then it is possible to determine what has been deleted.
  *

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/ChangeEditType.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/ChangeEditType.java
@@ -1,0 +1,29 @@
+package io.jenkins.plugins.forensics.delta.model;
+
+/**
+ * The edit type of a single change within a specific file.
+ *
+ * @author Florian Orendi
+ */
+public enum ChangeEditType {
+    /**
+     * The new content replaces old content.
+     */
+    REPLACE,
+    /**
+     * New content has been added.
+     */
+    INSERT,
+    /**
+     * Content has been deleted.
+     */
+    DELETE,
+    /**
+     * Nothing happened with the content.
+     */
+    EMPTY,
+    /**
+     * The edit type could not be determined.
+     */
+    UNDEFINED
+}

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
@@ -76,7 +76,7 @@ public class Delta implements Serializable {
     /**
      * Adds information about changes made to the specified file.
      *
-     * If there are already information about changes to the specified file, the old information will be overwritten by
+     * <p>If there are already information about changes to the specified file, the old information will be overwritten by
      * the new one.
      *
      * @param fileId

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
@@ -1,0 +1,70 @@
+package io.jenkins.plugins.forensics.delta.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Models the code difference - so called 'delta' - between two commits.
+ *
+ * @author Florian Orendi
+ */
+public class Delta implements Serializable {
+
+    private static final long serialVersionUID = 5641235877389921937L;
+
+    /**
+     * The currently processed commit.
+     */
+    private final String currentCommit;
+
+    /**
+     * The reference commit.
+     */
+    private final String referenceCommit;
+
+    /**
+     * The difference file created by Git.
+     */
+    private String diffFile;
+
+    /**
+     * Map which contains the changes for modified files, mapped by the file ID.
+     */
+    private Map<String, FileChanges> fileChanges;
+
+    public Delta(final String currentCommit, final String referenceCommit) {
+        this.currentCommit = currentCommit;
+        this.referenceCommit = referenceCommit;
+        this.diffFile = "";
+        this.fileChanges = new HashMap<>();
+    }
+
+    public static long getSerialVersionUID() {
+        return serialVersionUID;
+    }
+
+    public String getCurrentCommit() {
+        return currentCommit;
+    }
+
+    public String getReferenceCommit() {
+        return referenceCommit;
+    }
+
+    public String getDiffFile() {
+        return diffFile;
+    }
+
+    public void setDiffFile(final String diffFile) {
+        this.diffFile = diffFile;
+    }
+
+    public Map<String, FileChanges> getFileChanges() {
+        return fileChanges;
+    }
+
+    public void setFileChanges(final Map<String, FileChanges> fileChanges) {
+        this.fileChanges = fileChanges;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
@@ -1,8 +1,9 @@
 package io.jenkins.plugins.forensics.delta.model;
 
 import java.io.Serializable;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
@@ -13,6 +14,8 @@ import java.util.Objects;
 @SuppressWarnings("PMD.DataClass")
 public class Delta implements Serializable {
 
+    static final String ERROR_MESSAGE_UNKNOWN_FILE = "No information about changes for the file with the ID '%s' stored";
+
     private static final long serialVersionUID = 5641235877389921937L;
 
     private final String currentCommit;
@@ -22,7 +25,7 @@ public class Delta implements Serializable {
     /**
      * Map which contains the changes for modified files, mapped by the file ID.
      */
-    private final Map<String, FileChanges> fileChanges;
+    private final Map<String, FileChanges> fileChangesMap;
 
     /**
      * Constructor for a delta instance which wraps code changes between the two passed commits.
@@ -31,13 +34,14 @@ public class Delta implements Serializable {
      *         The currently processed commit
      * @param referenceCommit
      *         The reference commit
-     * @param fileChanges
+     * @param fileChangesMap
      *         The map which contains the changes for modified files, mapped by the file ID.
      */
-    public Delta(final String currentCommit, final String referenceCommit, final Map<String, FileChanges> fileChanges) {
+    public Delta(final String currentCommit, final String referenceCommit,
+            final Map<String, FileChanges> fileChangesMap) {
         this.currentCommit = currentCommit;
         this.referenceCommit = referenceCommit;
-        this.fileChanges = Collections.unmodifiableMap(fileChanges);
+        this.fileChangesMap = new HashMap<>(fileChangesMap);
     }
 
     public String getCurrentCommit() {
@@ -48,8 +52,40 @@ public class Delta implements Serializable {
         return referenceCommit;
     }
 
-    public Map<String, FileChanges> getFileChanges() {
-        return fileChanges;
+    public Map<String, FileChanges> getFileChangesMap() {
+        return new HashMap<>(fileChangesMap);
+    }
+
+    /**
+     * Returns information about changes made to the specified file.
+     *
+     * @param fileId
+     *         the ID of the file
+     *
+     * @return the information about changes made to the specified file
+     * @throws NoSuchElementException
+     *         if the file ID is not registered
+     */
+    public FileChanges getFileChangesById(final String fileId) {
+        if (fileChangesMap.containsKey(fileId)) {
+            return fileChangesMap.get(fileId);
+        }
+        throw new NoSuchElementException(String.format(ERROR_MESSAGE_UNKNOWN_FILE, fileId));
+    }
+
+    /**
+     * Adds information about changes made to the specified file.
+     * <p>
+     * If there are already information about changes to the specified file, the old information will be overwritten by
+     * the new one.
+     *
+     * @param fileId
+     *         The ID of the file
+     * @param fileChange
+     *         Information about the made changes
+     */
+    public void addFileChanges(final String fileId, final FileChanges fileChange) {
+        fileChangesMap.put(fileId, fileChange);
     }
 
     @Override
@@ -63,11 +99,11 @@ public class Delta implements Serializable {
         Delta delta = (Delta) o;
         return Objects.equals(currentCommit, delta.currentCommit)
                 && Objects.equals(referenceCommit, delta.referenceCommit)
-                && Objects.equals(fileChanges, delta.fileChanges);
+                && Objects.equals(fileChangesMap, delta.fileChangesMap);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(currentCommit, referenceCommit, fileChanges);
+        return Objects.hash(currentCommit, referenceCommit, fileChangesMap);
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
@@ -68,17 +68,21 @@ public class Delta implements Serializable {
     }
 
     public Map<String, FileChanges> getFileChanges() {
-        return fileChanges;
+        return new HashMap<>(fileChanges);
     }
 
     public void setFileChanges(final Map<String, FileChanges> fileChanges) {
-        this.fileChanges = fileChanges;
+        this.fileChanges = new HashMap<>(fileChanges);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Delta delta = (Delta) o;
         return Objects.equals(currentCommit, delta.currentCommit)
                 && Objects.equals(referenceCommit, delta.referenceCommit)

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
@@ -75,7 +75,7 @@ public class Delta implements Serializable {
 
     /**
      * Adds information about changes made to the specified file.
-     * <p>
+     *
      * If there are already information about changes to the specified file, the old information will be overwritten by
      * the new one.
      *

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
@@ -6,10 +6,11 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Models the code difference - so called 'delta' - between two commits.
+ * Data class that represents the code difference - so called 'delta' - between two commits.
  *
  * @author Florian Orendi
  */
+@SuppressWarnings("PMD.DataClass")
 public class Delta implements Serializable {
 
     private static final long serialVersionUID = 5641235877389921937L;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.forensics.delta.model;
 
 import java.io.Serializable;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -15,41 +15,29 @@ public class Delta implements Serializable {
 
     private static final long serialVersionUID = 5641235877389921937L;
 
-    /**
-     * The currently processed commit.
-     */
     private final String currentCommit;
 
-    /**
-     * The reference commit.
-     */
     private final String referenceCommit;
-
-    /**
-     * The difference file created by Git.
-     */
-    private String diffFile;
 
     /**
      * Map which contains the changes for modified files, mapped by the file ID.
      */
-    private Map<String, FileChanges> fileChanges;
+    private final Map<String, FileChanges> fileChanges;
 
     /**
      * Constructor for a delta instance which wraps code changes between the two passed commits.
      *
-     * @param currentCommit   The currently processed commit
-     * @param referenceCommit The reference commit
+     * @param currentCommit
+     *         The currently processed commit
+     * @param referenceCommit
+     *         The reference commit
+     * @param fileChanges
+     *         The map which contains the changes for modified files, mapped by the file ID.
      */
-    public Delta(final String currentCommit, final String referenceCommit) {
+    public Delta(final String currentCommit, final String referenceCommit, final Map<String, FileChanges> fileChanges) {
         this.currentCommit = currentCommit;
         this.referenceCommit = referenceCommit;
-        this.diffFile = "";
-        this.fileChanges = new HashMap<>();
-    }
-
-    public static long getSerialVersionUID() {
-        return serialVersionUID;
+        this.fileChanges = Collections.unmodifiableMap(fileChanges);
     }
 
     public String getCurrentCommit() {
@@ -60,20 +48,8 @@ public class Delta implements Serializable {
         return referenceCommit;
     }
 
-    public String getDiffFile() {
-        return diffFile;
-    }
-
-    public void setDiffFile(final String diffFile) {
-        this.diffFile = diffFile;
-    }
-
     public Map<String, FileChanges> getFileChanges() {
         return fileChanges;
-    }
-
-    public void setFileChanges(final Map<String, FileChanges> fileChanges) {
-        this.fileChanges = fileChanges;
     }
 
     @Override
@@ -87,12 +63,11 @@ public class Delta implements Serializable {
         Delta delta = (Delta) o;
         return Objects.equals(currentCommit, delta.currentCommit)
                 && Objects.equals(referenceCommit, delta.referenceCommit)
-                && Objects.equals(diffFile, delta.diffFile)
                 && Objects.equals(fileChanges, delta.fileChanges);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(currentCommit, referenceCommit, diffFile, fileChanges);
+        return Objects.hash(currentCommit, referenceCommit, fileChanges);
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.forensics.delta.model;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Models the code difference - so called 'delta' - between two commits.
@@ -33,6 +34,12 @@ public class Delta implements Serializable {
      */
     private Map<String, FileChanges> fileChanges;
 
+    /**
+     * Constructor for a delta instance which wraps code changes between the two passed commits.
+     *
+     * @param currentCommit   The currently processed commit
+     * @param referenceCommit The reference commit
+     */
     public Delta(final String currentCommit, final String referenceCommit) {
         this.currentCommit = currentCommit;
         this.referenceCommit = referenceCommit;
@@ -66,5 +73,21 @@ public class Delta implements Serializable {
 
     public void setFileChanges(final Map<String, FileChanges> fileChanges) {
         this.fileChanges = fileChanges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Delta delta = (Delta) o;
+        return Objects.equals(currentCommit, delta.currentCommit)
+                && Objects.equals(referenceCommit, delta.referenceCommit)
+                && Objects.equals(diffFile, delta.diffFile)
+                && Objects.equals(fileChanges, delta.fileChanges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currentCommit, referenceCommit, diffFile, fileChanges);
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Delta.java
@@ -69,11 +69,11 @@ public class Delta implements Serializable {
     }
 
     public Map<String, FileChanges> getFileChanges() {
-        return new HashMap<>(fileChanges);
+        return fileChanges;
     }
 
     public void setFileChanges(final Map<String, FileChanges> fileChanges) {
-        this.fileChanges = new HashMap<>(fileChanges);
+        this.fileChanges = fileChanges;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -2,8 +2,8 @@ package io.jenkins.plugins.forensics.delta.model;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -16,9 +16,6 @@ import java.util.stream.Stream;
  */
 @SuppressWarnings("PMD.DataClass")
 public class FileChanges implements Serializable {
-
-    static final String ERROR_MESSAGE_UNKNOWN_CHANGE_TYPE =
-            "No information about changes with the edit type '%s' stored";
 
     private static final long serialVersionUID = 6135245877389921937L;
 
@@ -79,15 +76,12 @@ public class FileChanges implements Serializable {
      *         The edit type
      *
      * @return the information about changes of the specified type
-     * @throws NoSuchElementException
-     *         if the file ID is not registered
      */
     public Set<Change> getChangesByType(final ChangeEditType changeEditType) {
         if (changes.containsKey(changeEditType)) {
             return changes.get(changeEditType);
         }
-        throw new NoSuchElementException(
-                String.format(ERROR_MESSAGE_UNKNOWN_CHANGE_TYPE, changeEditType));
+        return new HashSet<>();
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -48,7 +48,7 @@ public class FileChanges implements Serializable {
         this.fileName = fileName;
         this.fileContent = fileContent;
         this.fileEditType = fileEditType;
-        this.changes = changes;
+        this.changes = new HashMap<>(changes);
     }
 
     public String getFileName() {
@@ -68,9 +68,13 @@ public class FileChanges implements Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         FileChanges that = (FileChanges) o;
         return Objects.equals(fileName, that.fileName)
                 && Objects.equals(fileContent, that.fileContent)

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -15,14 +15,8 @@ public class FileChanges implements Serializable {
 
     private static final long serialVersionUID = 6135245877389921937L;
 
-    /**
-     * The file name.
-     */
     private final String fileName;
 
-    /**
-     * The new file content.
-     */
     private final String fileContent;
 
     /**
@@ -38,13 +32,17 @@ public class FileChanges implements Serializable {
     /**
      * Constructor for an instance which wraps all changes made to a specific file.
      *
-     * @param fileName     The name of the file
-     * @param fileContent  The content of the file
-     * @param fileEditType The change type how the file has been affected
-     * @param changes      The changes made to the file
+     * @param fileName
+     *         The name of the file
+     * @param fileContent
+     *         The content of the file
+     * @param fileEditType
+     *         The change type how the file has been affected
+     * @param changes
+     *         The changes made to the file
      */
     public FileChanges(final String fileName, final String fileContent, final FileEditType fileEditType,
-                       final Map<ChangeEditType, List<Change>> changes) {
+            final Map<ChangeEditType, List<Change>> changes) {
         this.fileName = fileName;
         this.fileContent = fileContent;
         this.fileEditType = fileEditType;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.forensics.delta.model;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -49,7 +49,7 @@ public class FileChanges implements Serializable {
         this.fileName = fileName;
         this.fileContent = fileContent;
         this.fileEditType = fileEditType;
-        this.changes = new HashMap<>(changes);
+        this.changes = changes;
     }
 
     public String getFileName() {
@@ -65,7 +65,7 @@ public class FileChanges implements Serializable {
     }
 
     public Map<ChangeEditType, List<Change>> getChanges() {
-        return new HashMap<>(changes);
+        return changes;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.forensics.delta.model;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -46,7 +47,7 @@ public class FileChanges implements Serializable {
         this.fileName = fileName;
         this.fileContent = fileContent;
         this.fileEditType = fileEditType;
-        this.changes = changes;
+        this.changes = Collections.unmodifiableMap(changes);
     }
 
     public String getFileName() {

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Wraps all changes made to one specific file.
@@ -34,8 +35,16 @@ public class FileChanges implements Serializable {
      */
     private final Map<ChangeEditType, List<Change>> changes;
 
+    /**
+     * Constructor for an instance which wraps all changes made to a specific file.
+     *
+     * @param fileName     The name of the file
+     * @param fileContent  The content of the file
+     * @param fileEditType The change type how the file has been affected
+     * @param changes      The changes made to the file
+     */
     public FileChanges(final String fileName, final String fileContent, final FileEditType fileEditType,
-            final Map<ChangeEditType, List<Change>> changes) {
+                       final Map<ChangeEditType, List<Change>> changes) {
         this.fileName = fileName;
         this.fileContent = fileContent;
         this.fileEditType = fileEditType;
@@ -56,5 +65,21 @@ public class FileChanges implements Serializable {
 
     public Map<ChangeEditType, List<Change>> getChanges() {
         return new HashMap<>(changes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileChanges that = (FileChanges) o;
+        return Objects.equals(fileName, that.fileName)
+                && Objects.equals(fileContent, that.fileContent)
+                && fileEditType == that.fileEditType
+                && Objects.equals(changes, that.changes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fileName, fileContent, fileEditType, changes);
     }
 }

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -1,0 +1,60 @@
+package io.jenkins.plugins.forensics.delta.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wraps all changes made to one specific file.
+ *
+ * @author Florian Orendi
+ */
+public class FileChanges implements Serializable {
+
+    private static final long serialVersionUID = 6135245877389921937L;
+
+    /**
+     * The file name.
+     */
+    private final String fileName;
+
+    /**
+     * The new file content.
+     */
+    private final String fileContent;
+
+    /**
+     * The {@link FileEditType} describing how the file has been affected.
+     */
+    private final FileEditType fileEditType;
+
+    /**
+     * A map changes made to the file, mapped by the {@link ChangeEditType}.
+     */
+    private final Map<ChangeEditType, List<Change>> changes;
+
+    public FileChanges(final String fileName, final String fileContent, final FileEditType fileEditType,
+            final Map<ChangeEditType, List<Change>> changes) {
+        this.fileName = fileName;
+        this.fileContent = fileContent;
+        this.fileEditType = fileEditType;
+        this.changes = changes;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public String getFileContent() {
+        return fileContent;
+    }
+
+    public FileEditType getFileEditType() {
+        return fileEditType;
+    }
+
+    public Map<ChangeEditType, List<Change>> getChanges() {
+        return new HashMap<>(changes);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -11,6 +11,7 @@ import java.util.Objects;
  *
  * @author Florian Orendi
  */
+@SuppressWarnings("PMD.DataClass")
 public class FileChanges implements Serializable {
 
     private static final long serialVersionUID = 6135245877389921937L;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileEditType.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileEditType.java
@@ -1,0 +1,33 @@
+package io.jenkins.plugins.forensics.delta.model;
+
+/**
+ * Edit types which describe how a file has been changed.
+ *
+ * @author Florian Orendi
+ */
+public enum FileEditType {
+    /**
+     * The file has been added.
+     */
+    ADD,
+    /**
+     * The file has been modified.
+     */
+    MODIFY,
+    /**
+     * The file has been deleted.
+     */
+    DELETE,
+    /**
+     * The file has been renamed.
+     */
+    RENAME,
+    /**
+     * The file has been copied.
+     */
+    COPY,
+    /**
+     * The edit type could not be determined.
+     */
+    UNDEFINED
+}

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/package-info.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/package-info.java
@@ -1,6 +1,8 @@
 /**
  * Contains the model which represents the calculated code delta.
- *
- * @author Florian Orendi
  */
+@DefaultAnnotation(NonNull.class)
 package io.jenkins.plugins.forensics.delta.model;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/package-info.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/package-info.java
@@ -1,5 +1,7 @@
 /**
  * Contains the model which represents the calculated code delta.
+ *
+ * @author Florian Orendi
  */
 @DefaultAnnotation(NonNull.class)
 package io.jenkins.plugins.forensics.delta.model;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/package-info.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Contains the model which represents the calculated code delta.
+ *
+ * @author Florian Orendi
+ */
+package io.jenkins.plugins.forensics.delta.model;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/package-info.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/package-info.java
@@ -1,5 +1,7 @@
 /**
  * Provides an API for calculating the code difference - so called 'delta' - between two commits.
+ *
+ * @author Florian Orendi
  */
 @DefaultAnnotation(NonNull.class)
 package io.jenkins.plugins.forensics.delta;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/package-info.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Provides an API for calculating the code difference - so called 'delta' - between two commits.
+ *
+ * @author Florian Orendi
+ */
+package io.jenkins.plugins.forensics.delta;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/package-info.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/package-info.java
@@ -1,6 +1,8 @@
 /**
  * Provides an API for calculating the code difference - so called 'delta' - between two commits.
- *
- * @author Florian Orendi
  */
+@DefaultAnnotation(NonNull.class)
 package io.jenkins.plugins.forensics.delta;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/src/test/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactoryITest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactoryITest.java
@@ -1,24 +1,26 @@
 package io.jenkins.plugins.forensics.delta;
 
-import edu.hm.hafner.util.FilteredLog;
-import hudson.FilePath;
-import hudson.model.Run;
-import hudson.model.TaskListener;
-import hudson.scm.SCM;
-import io.jenkins.plugins.forensics.delta.DeltaCalculator.NullDeltaCalculator;
-import io.jenkins.plugins.forensics.delta.model.Delta;
+import java.util.Collection;
+import java.util.Optional;
+
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 
-import java.util.Collection;
-import java.util.Optional;
+import edu.hm.hafner.util.FilteredLog;
 
-import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
-import static io.jenkins.plugins.util.PathStubs.asSourceDirectories;
-import static io.jenkins.plugins.util.PathStubs.createWorkspace;
-import static org.mockito.Mockito.mock;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.SCM;
+
+import io.jenkins.plugins.forensics.delta.DeltaCalculator.NullDeltaCalculator;
+import io.jenkins.plugins.forensics.delta.model.Delta;
+
+import static io.jenkins.plugins.forensics.assertions.Assertions.*;
+import static io.jenkins.plugins.util.PathStubs.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link DeltaCalculatorFactory}.
@@ -48,7 +50,8 @@ public class DeltaCalculatorFactoryITest {
 
         assertThat(nullCalculator).isInstanceOf(NullDeltaCalculator.class);
         assertThat(nullCalculator.calculateDelta("", "", log)).isEmpty();
-        assertThat(log.getInfoMessages()).containsOnly(NO_SUITABLE_DELTA_CALCULATOR_FOUND, ACTUAL_FACTORY_NULL_DELTA_CALCULATOR, EMPTY_FACTORY_NULL_DELTA_CALCULATOR);
+        assertThat(log.getInfoMessages()).containsOnly(NO_SUITABLE_DELTA_CALCULATOR_FOUND,
+                ACTUAL_FACTORY_NULL_DELTA_CALCULATOR, EMPTY_FACTORY_NULL_DELTA_CALCULATOR);
         assertThat(log.getErrorMessages()).isEmpty();
     }
 
@@ -67,17 +70,19 @@ public class DeltaCalculatorFactoryITest {
     }
 
     /**
-     * Verifies that correct {@link DeltaCalculator} instance is created for the second repository. (The first repository does
-     * return a {@link NullDeltaCalculator}.
+     * Verifies that correct {@link DeltaCalculator} instance is created for the second repository. (The first
+     * repository does return a {@link NullDeltaCalculator}.
      */
     @Test
     public void shouldSelectDeltaCalculatorForSecondDirectory() {
         FilteredLog log = new FilteredLog("Foo");
 
         Collection<FilePath> directories = asSourceDirectories(createWorkspace("/"), createWorkspace("/test"));
-        DeltaCalculator testDeltaSecondMatch = DeltaCalculatorFactory.findDeltaCalculator(mock(Run.class), directories, TaskListener.NULL, log);
+        DeltaCalculator testDeltaSecondMatch = DeltaCalculatorFactory.findDeltaCalculator(mock(Run.class), directories,
+                TaskListener.NULL, log);
         assertThat(log.getErrorMessages()).isEmpty();
-        assertThat(log.getInfoMessages()).containsOnly(EMPTY_FACTORY_NULL_DELTA_CALCULATOR, ACTUAL_FACTORY_NULL_DELTA_CALCULATOR,
+        assertThat(log.getInfoMessages()).containsOnly(EMPTY_FACTORY_NULL_DELTA_CALCULATOR,
+                ACTUAL_FACTORY_NULL_DELTA_CALCULATOR,
                 ACTUAL_FACTORY_CREATED_A_DELTA_CALCULATOR);
 
         assertThat(testDeltaSecondMatch).isInstanceOf(TestDeltaCalculator.class);
@@ -95,7 +100,8 @@ public class DeltaCalculatorFactoryITest {
         private static final long serialVersionUID = -2091805649078555383L;
 
         @Override
-        public Optional<Delta> calculateDelta(final String currentCommitId, final String referenceCommitId, final FilteredLog logger) {
+        public Optional<Delta> calculateDelta(final String currentCommitId, final String referenceCommitId,
+                final FilteredLog logger) {
             return Optional.empty();
         }
     }
@@ -107,8 +113,9 @@ public class DeltaCalculatorFactoryITest {
     @SuppressWarnings("unused")
     public static class EmptyFactory extends DeltaCalculatorFactory {
         @Override
-        public Optional<DeltaCalculator> createDeltaCalculator(final SCM scm, final Run<?, ?> run, final FilePath workspace,
-                                                               final TaskListener listener, final FilteredLog logger) {
+        public Optional<DeltaCalculator> createDeltaCalculator(final SCM scm, final Run<?, ?> run,
+                final FilePath workspace,
+                final TaskListener listener, final FilteredLog logger) {
             logger.logInfo(EMPTY_FACTORY_NULL_DELTA_CALCULATOR);
             return Optional.empty();
         }
@@ -122,7 +129,7 @@ public class DeltaCalculatorFactoryITest {
     public static class ActualFactory extends DeltaCalculatorFactory {
         @Override
         public Optional<DeltaCalculator> createDeltaCalculator(final SCM scm, final Run<?, ?> run,
-                                                               final FilePath workspace, final TaskListener listener, final FilteredLog logger) {
+                final FilePath workspace, final TaskListener listener, final FilteredLog logger) {
             if (workspace.getRemote().contains("test")) {
                 logger.logInfo(ACTUAL_FACTORY_CREATED_A_DELTA_CALCULATOR);
                 return Optional.of(new DeltaCalculatorFactoryITest.TestDeltaCalculator());

--- a/src/test/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactoryITest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactoryITest.java
@@ -1,0 +1,128 @@
+package io.jenkins.plugins.forensics.delta;
+
+import edu.hm.hafner.util.FilteredLog;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.SCM;
+import io.jenkins.plugins.forensics.blame.Blamer;
+import io.jenkins.plugins.forensics.delta.DeltaCalculator.NullDeltaCalculator;
+import io.jenkins.plugins.forensics.delta.model.Delta;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
+import static io.jenkins.plugins.util.PathStubs.asSourceDirectories;
+import static io.jenkins.plugins.util.PathStubs.createWorkspace;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests the class {@link DeltaCalculatorFactory}.
+ *
+ * @author Florian Orendi
+ */
+public class DeltaCalculatorFactoryITest {
+
+    @ClassRule
+    public static final JenkinsRule JENKINS_PER_SUITE = new JenkinsRule();
+
+    private static final String NO_SUITABLE_DELTA_CALCULATOR_FOUND = "-> No suitable delta calculator found.";
+    private static final String ACTUAL_FACTORY_NULL_DELTA_CALCULATOR = "ActualFactory returned NullDeltaCalculator";
+    private static final String EMPTY_FACTORY_NULL_DELTA_CALCULATOR = "EmptyFactory returned NullDeltaCalculator";
+    private static final String ACTUAL_FACTORY_CREATED_A_DELTA_CALCULATOR = "ActualFactory created a DeltaCalculator";
+
+    /** Verifies that a {@link NullDeltaCalculator} will be returned if no suitable delta calculator has been found. */
+    @Test
+    public void shouldSelectNullDeltaCalculator() {
+        FilteredLog log = new FilteredLog("Foo");
+        DeltaCalculator nullCalculator = createDeltaCalculator("/", log);
+
+        assertThat(nullCalculator).isInstanceOf(NullDeltaCalculator.class);
+        assertThat(nullCalculator.calculateDelta("", "", log)).isEmpty();
+        assertThat(log.getInfoMessages()).containsOnly(NO_SUITABLE_DELTA_CALCULATOR_FOUND, ACTUAL_FACTORY_NULL_DELTA_CALCULATOR, EMPTY_FACTORY_NULL_DELTA_CALCULATOR);
+        assertThat(log.getErrorMessages()).isEmpty();
+    }
+
+    /** Verifies that the correct {@link DeltaCalculator} instance is created for the first repository. */
+    @Test
+    public void shouldSelectDeltaCalculatorForFirstDirectory() {
+        FilteredLog log = new FilteredLog("Foo");
+        DeltaCalculator deltaCalculator = createDeltaCalculator("/test", log);
+
+        assertThat(log.getErrorMessages()).isEmpty();
+        assertThat(log.getInfoMessages()).containsOnly(ACTUAL_FACTORY_CREATED_A_DELTA_CALCULATOR);
+
+        assertThat(deltaCalculator).isInstanceOf(TestDeltaCalculator.class);
+    }
+
+    /**
+     * Verifies that correct {@link DeltaCalculator} instance is created for the second repository. (The first repository does
+     * return a {@link NullDeltaCalculator}.
+     */
+    @Test
+    public void shouldSelectDeltaCalculatorForSecondDirectory() {
+        FilteredLog log = new FilteredLog("Foo");
+
+        Collection<FilePath> directories = asSourceDirectories(createWorkspace("/"), createWorkspace("/test"));
+        DeltaCalculator testDeltaSecondMatch = DeltaCalculatorFactory.findDeltaCalculator(mock(Run.class), directories, TaskListener.NULL, log);
+        assertThat(log.getErrorMessages()).isEmpty();
+        assertThat(log.getInfoMessages()).containsOnly(EMPTY_FACTORY_NULL_DELTA_CALCULATOR, ACTUAL_FACTORY_NULL_DELTA_CALCULATOR,
+                ACTUAL_FACTORY_CREATED_A_DELTA_CALCULATOR);
+
+        assertThat(testDeltaSecondMatch).isInstanceOf(TestDeltaCalculator.class);
+    }
+
+    private DeltaCalculator createDeltaCalculator(final String path, final FilteredLog log) {
+        return DeltaCalculatorFactory.findDeltaCalculator(mock(Run.class), asSourceDirectories(createWorkspace(path)),
+                TaskListener.NULL, log);
+    }
+
+    /**
+     * A delta calculator for the test.
+     */
+    private static class TestDeltaCalculator extends DeltaCalculator {
+        private static final long serialVersionUID = -2091805649078555383L;
+
+        @Override
+        public Optional<Delta> calculateDelta(String currentCommitId, String referenceCommitId, FilteredLog logger) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Factory that does not return a delta calculator.
+     */
+    @TestExtension
+    @SuppressWarnings("unused")
+    public static class EmptyFactory extends DeltaCalculatorFactory {
+        @Override
+        public Optional<DeltaCalculator> createDeltaCalculator(final SCM scm, final Run<?, ?> run, final FilePath workspace,
+                                                               final TaskListener listener, final FilteredLog logger) {
+            logger.logInfo(EMPTY_FACTORY_NULL_DELTA_CALCULATOR);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Factory that returns a delta calculator if the workspace contains the String {@code test}.
+     */
+    @TestExtension
+    @SuppressWarnings("unused")
+    public static class ActualFactory extends DeltaCalculatorFactory {
+        @Override
+        public Optional<DeltaCalculator> createDeltaCalculator(final SCM scm, final Run<?, ?> run,
+                                                               final FilePath workspace, final TaskListener listener, final FilteredLog logger) {
+            if (workspace.getRemote().contains("test")) {
+                logger.logInfo(ACTUAL_FACTORY_CREATED_A_DELTA_CALCULATOR);
+                return Optional.of(new DeltaCalculatorFactoryITest.TestDeltaCalculator());
+            }
+            logger.logInfo(ACTUAL_FACTORY_NULL_DELTA_CALCULATOR);
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactoryITest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactoryITest.java
@@ -5,7 +5,6 @@ import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
-import io.jenkins.plugins.forensics.blame.Blamer;
 import io.jenkins.plugins.forensics.delta.DeltaCalculator.NullDeltaCalculator;
 import io.jenkins.plugins.forensics.delta.model.Delta;
 import org.junit.ClassRule;
@@ -28,6 +27,9 @@ import static org.mockito.Mockito.mock;
  */
 public class DeltaCalculatorFactoryITest {
 
+    /**
+     * Jenkins rule per suite.
+     */
     @ClassRule
     public static final JenkinsRule JENKINS_PER_SUITE = new JenkinsRule();
 
@@ -36,7 +38,9 @@ public class DeltaCalculatorFactoryITest {
     private static final String EMPTY_FACTORY_NULL_DELTA_CALCULATOR = "EmptyFactory returned NullDeltaCalculator";
     private static final String ACTUAL_FACTORY_CREATED_A_DELTA_CALCULATOR = "ActualFactory created a DeltaCalculator";
 
-    /** Verifies that a {@link NullDeltaCalculator} will be returned if no suitable delta calculator has been found. */
+    /**
+     * Verifies that a {@link NullDeltaCalculator} will be returned if no suitable delta calculator has been found.
+     */
     @Test
     public void shouldSelectNullDeltaCalculator() {
         FilteredLog log = new FilteredLog("Foo");
@@ -48,7 +52,9 @@ public class DeltaCalculatorFactoryITest {
         assertThat(log.getErrorMessages()).isEmpty();
     }
 
-    /** Verifies that the correct {@link DeltaCalculator} instance is created for the first repository. */
+    /**
+     * Verifies that the correct {@link DeltaCalculator} instance is created for the first repository.
+     */
     @Test
     public void shouldSelectDeltaCalculatorForFirstDirectory() {
         FilteredLog log = new FilteredLog("Foo");
@@ -89,7 +95,7 @@ public class DeltaCalculatorFactoryITest {
         private static final long serialVersionUID = -2091805649078555383L;
 
         @Override
-        public Optional<Delta> calculateDelta(String currentCommitId, String referenceCommitId, FilteredLog logger) {
+        public Optional<Delta> calculateDelta(final String currentCommitId, final String referenceCommitId, final FilteredLog logger) {
             return Optional.empty();
         }
     }

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
@@ -1,9 +1,10 @@
 package io.jenkins.plugins.forensics.delta.model;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+import static io.jenkins.plugins.forensics.assertions.Assertions.*;
 
 /**
  * Tests the class {@link Change}.
@@ -16,24 +17,25 @@ class ChangeTest {
     private static final int FROM_LINE = 1;
     private static final int TO_LINE = 3;
 
-    private static Change change;
-
-    @BeforeAll
-    static void init() {
-        change = new Change(EDIT_TYPE, FROM_LINE, TO_LINE);
-    }
-
     @Test
     void testChangeGetters() {
+        final Change change = createChange();
         assertThat(change.getEditType()).isEqualTo(EDIT_TYPE);
         assertThat(change.getFromLine()).isEqualTo(FROM_LINE);
         assertThat(change.getToLine()).isEqualTo(TO_LINE);
     }
 
     @Test
-    void testChangeSetters() {
-        Change changeTwo = new Change(EDIT_TYPE, FROM_LINE, TO_LINE);
+    void shouldObeyEqualsContract() {
+        EqualsVerifier.simple().forClass(Change.class).verify();
+    }
 
-        assertThat(change).isEqualTo(changeTwo);
+    /**
+     * Factory method which creates an instance of {@link Change}.
+     *
+     * @return the created instance
+     */
+    private Change createChange() {
+        return new Change(EDIT_TYPE, FROM_LINE, TO_LINE);
     }
 }

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
@@ -19,7 +19,7 @@ class ChangeTest {
 
     @Test
     void testChangeGetters() {
-        final Change change = createChange();
+        Change change = createChange();
         assertThat(change.getEditType()).isEqualTo(EDIT_TYPE);
         assertThat(change.getFromLine()).isEqualTo(FROM_LINE);
         assertThat(change.getToLine()).isEqualTo(TO_LINE);

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins.forensics.delta.model;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
+
+/**
+ * Tests the class {@link Change}.
+ *
+ * @author Florian Orendi
+ */
+class ChangeTest {
+
+    private static final ChangeEditType EDIT_TYPE = ChangeEditType.INSERT;
+    private static final int FROM_LINE = 1;
+    private static final int TO_LINE = 3;
+
+    private static Change change;
+
+    @BeforeAll
+    static void init() {
+        change = new Change(EDIT_TYPE, FROM_LINE, TO_LINE);
+    }
+
+    @Test
+    void testChangeGetters() {
+        assertThat(change.getEditType()).isEqualTo(EDIT_TYPE);
+        assertThat(change.getFromLine()).isEqualTo(FROM_LINE);
+        assertThat(change.getToLine()).isEqualTo(TO_LINE);
+    }
+
+    @Test
+    void testChangeSetters() {
+        Change changeTwo = new Change(EDIT_TYPE, FROM_LINE, TO_LINE);
+
+        assertThat(change).isEqualTo(changeTwo);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/DeltaTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/DeltaTest.java
@@ -1,14 +1,15 @@
 package io.jenkins.plugins.forensics.delta.model;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+import static io.jenkins.plugins.forensics.assertions.Assertions.*;
 
 /**
  * Tests the class {@link Delta}.
@@ -20,45 +21,33 @@ class DeltaTest {
     private static final String CURRENT_COMMIT_ID = "testIdOne";
     private static final String REFERENCE_COMMIT_ID = "testIdTwo";
 
-    private static Delta delta;
-
-    @BeforeAll
-    static void init() {
-        delta = new Delta(CURRENT_COMMIT_ID, REFERENCE_COMMIT_ID);
-    }
+    private static Map<String, FileChanges> fileChangesMap = new HashMap<>();
 
     @Test
-    void testChangeGettersAndSetters() {
-        String diffFileContent = "testContent";
-        delta.setDiffFile(diffFileContent);
-        Map<String, FileChanges> fileChanges = createFileChanges();
-        delta.setFileChanges(fileChanges);
-
+    void testDeltaGetters() {
+        Delta delta = createDelta();
         assertThat(delta.getCurrentCommit()).isEqualTo(CURRENT_COMMIT_ID);
         assertThat(delta.getReferenceCommit()).isEqualTo(REFERENCE_COMMIT_ID);
-        assertThat(delta.getDiffFile()).isEqualTo(diffFileContent);
-        assertThat(delta.getFileChanges()).isEqualTo(fileChanges);
+        assertThat(delta.getFileChanges()).isEqualTo(fileChangesMap);
     }
 
     @Test
-    void testChangeSetters() {
-        Delta deltaTwo = new Delta(CURRENT_COMMIT_ID, REFERENCE_COMMIT_ID);
-
-        assertThat(delta).isEqualTo(deltaTwo);
+    void shouldObeyEqualsContract() {
+        EqualsVerifier.simple().forClass(Delta.class).verify();
     }
 
     /**
-     * Creates a map which contains {@link FileChanges} mapped by the file ID.
+     * Factory method which creates an instance of {@link Delta}.
      *
-     * @return the created map
+     * @return the created instance
      */
-    private Map<String, FileChanges> createFileChanges() {
+    private Delta createDelta() {
         ChangeEditType editType = ChangeEditType.INSERT;
         List<Change> changes = Collections.singletonList(new Change(editType, 1, 6));
         Map<ChangeEditType, List<Change>> changesMap = new HashMap<>();
         changesMap.put(editType, changes);
-        Map<String, FileChanges> fileChangesMap = new HashMap<>();
+        fileChangesMap = new HashMap<>();
         fileChangesMap.put("testKey", new FileChanges("test", "test", FileEditType.ADD, changesMap));
-        return fileChangesMap;
+        return new Delta(CURRENT_COMMIT_ID, REFERENCE_COMMIT_ID, fileChangesMap);
     }
 }

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/DeltaTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/DeltaTest.java
@@ -15,7 +15,7 @@ import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
  *
  * @author Florian Orendi
  */
-public class DeltaTest {
+class DeltaTest {
 
     private static final String CURRENT_COMMIT_ID = "testIdOne";
     private static final String REFERENCE_COMMIT_ID = "testIdTwo";

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/DeltaTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/DeltaTest.java
@@ -1,0 +1,64 @@
+package io.jenkins.plugins.forensics.delta.model;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
+
+/**
+ * Tests the class {@link Delta}.
+ *
+ * @author Florian Orendi
+ */
+public class DeltaTest {
+
+    private static final String CURRENT_COMMIT_ID = "testIdOne";
+    private static final String REFERENCE_COMMIT_ID = "testIdTwo";
+
+    private static Delta delta;
+
+    @BeforeAll
+    static void init() {
+        delta = new Delta(CURRENT_COMMIT_ID, REFERENCE_COMMIT_ID);
+    }
+
+    @Test
+    void testChangeGettersAndSetters() {
+        String diffFileContent = "testContent";
+        delta.setDiffFile(diffFileContent);
+        Map<String, FileChanges> fileChanges = createFileChanges();
+        delta.setFileChanges(fileChanges);
+
+        assertThat(delta.getCurrentCommit()).isEqualTo(CURRENT_COMMIT_ID);
+        assertThat(delta.getReferenceCommit()).isEqualTo(REFERENCE_COMMIT_ID);
+        assertThat(delta.getDiffFile()).isEqualTo(diffFileContent);
+        assertThat(delta.getFileChanges()).isEqualTo(fileChanges);
+    }
+
+    @Test
+    void testChangeSetters() {
+        Delta deltaTwo = new Delta(CURRENT_COMMIT_ID, REFERENCE_COMMIT_ID);
+
+        assertThat(delta).isEqualTo(deltaTwo);
+    }
+
+    /**
+     * Creates a map which contains {@link FileChanges} mapped by the file ID.
+     *
+     * @return the created map
+     */
+    private Map<String, FileChanges> createFileChanges() {
+        ChangeEditType editType = ChangeEditType.INSERT;
+        List<Change> changes = Collections.singletonList(new Change(editType, 1, 6));
+        Map<ChangeEditType, List<Change>> changesMap = new HashMap<>();
+        changesMap.put(editType, changes);
+        Map<String, FileChanges> fileChangesMap = new HashMap<>();
+        fileChangesMap.put("testKey", new FileChanges("test", "test", FileEditType.ADD, changesMap));
+        return fileChangesMap;
+    }
+}

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/DeltaTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/DeltaTest.java
@@ -1,8 +1,6 @@
 package io.jenkins.plugins.forensics.delta.model;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -20,15 +18,14 @@ class DeltaTest {
 
     private static final String CURRENT_COMMIT_ID = "testIdOne";
     private static final String REFERENCE_COMMIT_ID = "testIdTwo";
-
-    private static Map<String, FileChanges> fileChangesMap = new HashMap<>();
+    private static final Map<String, FileChanges> FILE_CHANGES_MAP = Collections.emptyMap();
 
     @Test
     void testDeltaGetters() {
         Delta delta = createDelta();
         assertThat(delta.getCurrentCommit()).isEqualTo(CURRENT_COMMIT_ID);
         assertThat(delta.getReferenceCommit()).isEqualTo(REFERENCE_COMMIT_ID);
-        assertThat(delta.getFileChanges()).isEqualTo(fileChangesMap);
+        assertThat(delta.getFileChanges()).isEqualTo(FILE_CHANGES_MAP);
     }
 
     @Test
@@ -42,12 +39,6 @@ class DeltaTest {
      * @return the created instance
      */
     private Delta createDelta() {
-        ChangeEditType editType = ChangeEditType.INSERT;
-        List<Change> changes = Collections.singletonList(new Change(editType, 1, 6));
-        Map<ChangeEditType, List<Change>> changesMap = new HashMap<>();
-        changesMap.put(editType, changes);
-        fileChangesMap = new HashMap<>();
-        fileChangesMap.put("testKey", new FileChanges("test", "test", FileEditType.ADD, changesMap));
-        return new Delta(CURRENT_COMMIT_ID, REFERENCE_COMMIT_ID, fileChangesMap);
+        return new Delta(CURRENT_COMMIT_ID, REFERENCE_COMMIT_ID, FILE_CHANGES_MAP);
     }
 }

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.forensics.delta.model;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -39,20 +38,14 @@ class FileChangesTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenGettingChangesOfUnknownType() {
-        FileChanges fileChanges = createFileChanges();
-        assertThatExceptionOfType(NoSuchElementException.class)
-                .isThrownBy(() -> fileChanges.getChangesByType(ChangeEditType.UNDEFINED))
-                .withMessage(FileChanges.ERROR_MESSAGE_UNKNOWN_CHANGE_TYPE, ChangeEditType.UNDEFINED);
-    }
-
-    @Test
     void shouldAddChange() {
         FileChanges fileChanges = createFileChanges();
 
-        assertThat(fileChanges.getChanges()).isEmpty();
-
         ChangeEditType changeEditType = ChangeEditType.REPLACE;
+
+        assertThat(fileChanges.getChanges()).isEmpty();
+        assertThat(fileChanges.getChangesByType(changeEditType)).isEmpty();
+
         Change change = Mockito.mock(Change.class);
         Mockito.when(change.getEditType()).thenReturn(changeEditType);
 

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
@@ -1,0 +1,50 @@
+package io.jenkins.plugins.forensics.delta.model;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
+
+/**
+ * Tests the class {@link FileChanges}.
+ *
+ * @author Florian Orendi
+ */
+class FileChangesTest {
+
+    private static final String FILE_NAME = "test";
+    private static final String FILE_CONTENT = "test";
+    private static final FileEditType FILE_EDIT_TYPE = FileEditType.ADD;
+
+    private static Map<ChangeEditType, List<Change>> changesMap;
+
+    private static FileChanges fileChanges;
+
+    @BeforeAll
+    static void init() {
+        ChangeEditType editType = ChangeEditType.INSERT;
+        List<Change> changes = Collections.singletonList(new Change(editType, 1, 6));
+        changesMap = new HashMap<>();
+        changesMap.put(editType, changes);
+        fileChanges = new FileChanges(FILE_NAME, FILE_CONTENT, FILE_EDIT_TYPE, changesMap);
+    }
+
+    @Test
+    void testFileChangesGetter() {
+        assertThat(fileChanges.getFileName()).isEqualTo(FILE_NAME);
+        assertThat(fileChanges.getFileContent()).isEqualTo(FILE_CONTENT);
+        assertThat(fileChanges.getFileEditType()).isEqualTo(FILE_EDIT_TYPE);
+        assertThat(fileChanges.getChanges()).isEqualTo(changesMap);
+    }
+
+    @Test
+    void testFileChangesEquals() {
+        FileChanges fileChangesTwo = new FileChanges(FILE_NAME, FILE_CONTENT, FILE_EDIT_TYPE, changesMap);
+        assertThat(fileChanges).isEqualTo(fileChangesTwo);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.forensics.delta.model;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -21,8 +20,7 @@ class FileChangesTest {
     private static final String FILE_NAME = "test";
     private static final String FILE_CONTENT = "test";
     private static final FileEditType FILE_EDIT_TYPE = FileEditType.ADD;
-
-    private static Map<ChangeEditType, List<Change>> changesMap = new HashMap<>();
+    private static final Map<ChangeEditType, List<Change>> FILE_CHANGES = Collections.emptyMap();
 
     @Test
     void testFileChangesGetter() {
@@ -30,7 +28,7 @@ class FileChangesTest {
         assertThat(fileChanges.getFileName()).isEqualTo(FILE_NAME);
         assertThat(fileChanges.getFileContent()).isEqualTo(FILE_CONTENT);
         assertThat(fileChanges.getFileEditType()).isEqualTo(FILE_EDIT_TYPE);
-        assertThat(fileChanges.getChanges()).isEqualTo(changesMap);
+        assertThat(fileChanges.getChanges()).isEqualTo(FILE_CHANGES);
     }
 
     @Test
@@ -44,10 +42,6 @@ class FileChangesTest {
      * @return the created instance
      */
     private FileChanges createFileChanges() {
-        ChangeEditType editType = ChangeEditType.INSERT;
-        List<Change> changes = Collections.singletonList(new Change(editType, 1, 6));
-        changesMap = new HashMap<>();
-        changesMap.put(editType, changes);
-        return new FileChanges(FILE_NAME, FILE_CONTENT, FILE_EDIT_TYPE, changesMap);
+        return new FileChanges(FILE_NAME, FILE_CONTENT, FILE_EDIT_TYPE, FILE_CHANGES);
     }
 }

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
@@ -1,14 +1,15 @@
 package io.jenkins.plugins.forensics.delta.model;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+import static io.jenkins.plugins.forensics.assertions.Assertions.*;
 
 /**
  * Tests the class {@link FileChanges}.
@@ -21,21 +22,11 @@ class FileChangesTest {
     private static final String FILE_CONTENT = "test";
     private static final FileEditType FILE_EDIT_TYPE = FileEditType.ADD;
 
-    private static Map<ChangeEditType, List<Change>> changesMap;
-
-    private static FileChanges fileChanges;
-
-    @BeforeAll
-    static void init() {
-        ChangeEditType editType = ChangeEditType.INSERT;
-        List<Change> changes = Collections.singletonList(new Change(editType, 1, 6));
-        changesMap = new HashMap<>();
-        changesMap.put(editType, changes);
-        fileChanges = new FileChanges(FILE_NAME, FILE_CONTENT, FILE_EDIT_TYPE, changesMap);
-    }
+    private static Map<ChangeEditType, List<Change>> changesMap = new HashMap<>();
 
     @Test
     void testFileChangesGetter() {
+        final FileChanges fileChanges = createFileChanges();
         assertThat(fileChanges.getFileName()).isEqualTo(FILE_NAME);
         assertThat(fileChanges.getFileContent()).isEqualTo(FILE_CONTENT);
         assertThat(fileChanges.getFileEditType()).isEqualTo(FILE_EDIT_TYPE);
@@ -43,8 +34,20 @@ class FileChangesTest {
     }
 
     @Test
-    void testFileChangesEquals() {
-        FileChanges fileChangesTwo = new FileChanges(FILE_NAME, FILE_CONTENT, FILE_EDIT_TYPE, changesMap);
-        assertThat(fileChanges).isEqualTo(fileChangesTwo);
+    void shouldObeyEqualsContract() {
+        EqualsVerifier.simple().forClass(FileChanges.class).verify();
+    }
+
+    /**
+     * Factory method which creates an instance of {@link FileChanges}.
+     *
+     * @return the created instance
+     */
+    private FileChanges createFileChanges() {
+        ChangeEditType editType = ChangeEditType.INSERT;
+        List<Change> changes = Collections.singletonList(new Change(editType, 1, 6));
+        changesMap = new HashMap<>();
+        changesMap.put(editType, changes);
+        return new FileChanges(FILE_NAME, FILE_CONTENT, FILE_EDIT_TYPE, changesMap);
     }
 }

--- a/src/test/resources/design.puml
+++ b/src/test/resources/design.puml
@@ -7,6 +7,7 @@ skinparam component {
 }
 
 [Blamer] <<..blame..>>
+[Delta] <<..delta..>>
 [Miner] <<..miner>>
 [Reference Recorder] <<..reference..>>
 
@@ -14,6 +15,7 @@ skinparam component {
 
 [Blamer] --> [Utilities]
 [Miner] --> [Utilities]
+[Delta] --> [Utilities]
 [Miner] -> [Reference Recorder]
 [Reference Recorder] --> [Utilities]
 


### PR DESCRIPTION
An API which calculates the code differences - so called 'delta' - between two commits.
The resulting delta model contains information about:
- which files have been changed in which way
- which concrete lines within these files have been changed in which way

The implementation for Git is available in the downstream PR jenkinsci/git-forensics-plugin#390