### PR TITLE
Provide affected lines for code delta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
                   <method>createXmlStream</method>
                   <justification>This method is not intended to be overwritten</justification>
                 </item>
+                <item>
+                  <code>java.field.serialVersionUIDUnchanged</code>
+                  <classSimpleName>Change</classSimpleName>
+                  <justification>This API is not finally in use yet.</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -6,9 +6,9 @@ import java.util.Objects;
 /**
  * A change made on specific lines within a specific file.
  *
- * <p>The interval of lines which contain the change is defined by a starting and an ending point (1-based line
- * counter). Also, the lines of the file before the change has been inserted is specified by a starting and an ending
- * point, as already described, in order to be able to determine removed lines for example.
+ * <p>The interval of lines which contains the change is defined by a starting and an ending point (1-based line
+ * counter). Also, the affected lines of the file before the change has been inserted are specified by a starting and an
+ * ending point, as already described, in order to be able to determine removed lines for example.
  *
  * @author Florian Orendi
  */
@@ -97,17 +97,6 @@ public class Change implements Serializable {
 
     public int getToLine() {
         return toLine;
-    }
-
-    /**
-     * Called after de-serialization to retain backward compatibility.
-     *
-     * @return this
-     */
-    protected Object readResolve() {
-        changedFromLine = 0;
-        changedToLine = 0;
-        return this;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -53,9 +53,7 @@ public class Change implements Serializable {
      */
     @Deprecated
     public Change(final ChangeEditType changeEditType, final int fromLine, final int toLine) {
-        this.changeEditType = changeEditType;
-        this.fromLine = fromLine;
-        this.toLine = toLine;
+        this(changeEditType, 0, 0, fromLine, toLine);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -50,6 +50,7 @@ public class Change implements Serializable {
      * @param toLine
      *         The ending line
      */
+    @Deprecated
     public Change(final ChangeEditType changeEditType, final int fromLine, final int toLine) {
         this.changeEditType = changeEditType;
         this.fromLine = fromLine;

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/Change.java
@@ -40,15 +40,16 @@ public class Change implements Serializable {
     /**
      * Constructor for an instance which wraps a specific change within a file.
      *
-     * <p>This constructor is deprecated since it does not initialize the interval which provides the information about
-     * which lines of the original file has been affected by the change. This interval will be initialized with '0'.
-     *
      * @param changeEditType
      *         The type of the change
      * @param fromLine
      *         The starting line
      * @param toLine
      *         The ending line
+     *
+     * @deprecated This constructor is deprecated since it does not initialize the interval which provides the
+     *         information about which lines of the original file has been affected by the change. This interval will be
+     *         initialized with '0'.
      */
     @Deprecated
     public Change(final ChangeEditType changeEditType, final int fromLine, final int toLine) {

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
@@ -14,6 +14,8 @@ import static io.jenkins.plugins.forensics.assertions.Assertions.*;
 class ChangeTest {
 
     private static final ChangeEditType EDIT_TYPE = ChangeEditType.INSERT;
+    private static final int CHANGED_FROM_LINE = 1;
+    private static final int CHANGED_TO_LINE = 1;
     private static final int FROM_LINE = 1;
     private static final int TO_LINE = 3;
 
@@ -21,6 +23,8 @@ class ChangeTest {
     void testChangeGetters() {
         Change change = createChange();
         assertThat(change.getEditType()).isEqualTo(EDIT_TYPE);
+        assertThat(change.getChangedFromLine()).isEqualTo(CHANGED_FROM_LINE);
+        assertThat(change.getChangedToLine()).isEqualTo(CHANGED_TO_LINE);
         assertThat(change.getFromLine()).isEqualTo(FROM_LINE);
         assertThat(change.getToLine()).isEqualTo(TO_LINE);
     }
@@ -36,6 +40,6 @@ class ChangeTest {
      * @return the created instance
      */
     private Change createChange() {
-        return new Change(EDIT_TYPE, FROM_LINE, TO_LINE);
+        return new Change(EDIT_TYPE, CHANGED_FROM_LINE, CHANGED_TO_LINE, FROM_LINE, TO_LINE);
     }
 }

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
@@ -20,13 +20,20 @@ class ChangeTest {
     private static final int TO_LINE = 3;
 
     @Test
-    void testChangeGetters() {
+    void shouldHaveWorkingGetters() {
         Change change = createChange();
         assertThat(change.getEditType()).isEqualTo(EDIT_TYPE);
         assertThat(change.getChangedFromLine()).isEqualTo(CHANGED_FROM_LINE);
         assertThat(change.getChangedToLine()).isEqualTo(CHANGED_TO_LINE);
         assertThat(change.getFromLine()).isEqualTo(FROM_LINE);
         assertThat(change.getToLine()).isEqualTo(TO_LINE);
+    }
+
+    @Test
+    void shouldInitializeChangedLinesPerDefault() {
+        Change change = new Change(EDIT_TYPE, FROM_LINE, TO_LINE);
+        assertThat(change.getChangedFromLine()).isEqualTo(0);
+        assertThat(change.getChangedToLine()).isEqualTo(0);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/ChangeTest.java
@@ -22,18 +22,18 @@ class ChangeTest {
     @Test
     void shouldHaveWorkingGetters() {
         Change change = createChange();
-        assertThat(change.getEditType()).isEqualTo(EDIT_TYPE);
-        assertThat(change.getChangedFromLine()).isEqualTo(CHANGED_FROM_LINE);
-        assertThat(change.getChangedToLine()).isEqualTo(CHANGED_TO_LINE);
-        assertThat(change.getFromLine()).isEqualTo(FROM_LINE);
-        assertThat(change.getToLine()).isEqualTo(TO_LINE);
+        assertThat(change).hasEditType(EDIT_TYPE);
+        assertThat(change).hasChangedFromLine(CHANGED_FROM_LINE);
+        assertThat(change).hasChangedToLine(CHANGED_TO_LINE);
+        assertThat(change).hasFromLine(FROM_LINE);
+        assertThat(change).hasToLine(TO_LINE);
     }
 
     @Test
     void shouldInitializeChangedLinesPerDefault() {
         Change change = new Change(EDIT_TYPE, FROM_LINE, TO_LINE);
-        assertThat(change.getChangedFromLine()).isEqualTo(0);
-        assertThat(change.getChangedToLine()).isEqualTo(0);
+        assertThat(change).hasChangedFromLine(0);
+        assertThat(change).hasChangedToLine(0);
     }
 
     @Test


### PR DESCRIPTION
I expanded the code delta API that it also provides the affected lines, which will be changed by a new commit, as they were before the change has been made.