### PR TITLE
Choose SCM when calculating the code delta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,10 +171,18 @@
                   <justification>This API is not finally in use yet.</justification>
                 </item>
                 <item>
-                  <code>java.method.abstractMethodAdded</code>
-                  <classSimpleName>DeltaCalculator</classSimpleName>
-                  <method>calculateDelta</method>
-                  <justification>The new method is required when no commit IDs are accessible.</justification>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <package>io.jenkins.plugins.forensics.delta</package>
+                  <methodName>calculateDelta</methodName>
+                  <justification>The additional parameter is required for calculating the code delta.</justification>
+                </item>
+                <item>
+                  <code>java.method.removed</code>
+                  <package>io.jenkins.plugins.forensics.delta</package>
+                  <methodName>calculateDelta</methodName>
+                  <justification>
+                    The removed methods are not required any more for calculating the code delta.
+                  </justification>
                 </item>
               </differences>
             </revapi.differences>

--- a/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculator.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/DeltaCalculator.java
@@ -19,34 +19,21 @@ public abstract class DeltaCalculator implements Serializable {
     private static final long serialVersionUID = 8641535877389921937L;
 
     /**
-     * Calculates the {@link Delta} between two passed commits.
-     *
-     * @param currentCommitId
-     *         The currently processed commit ID
-     * @param referenceCommitId
-     *         The reference commit ID
-     * @param logger
-     *         The used log
-     *
-     * @return the delta if it could be calculated
-     */
-    public abstract Optional<Delta> calculateDelta(String currentCommitId, String referenceCommitId,
-            FilteredLog logger);
-
-    /**
      * Calculates the {@link Delta} between two passed Jenkins builds.
      *
      * @param build
      *         The currently processed build
      * @param referenceBuild
      *         The reference build
+     * @param scmKeyFilter
+     *         The SCM key filter
      * @param logger
      *         The used log
      *
      * @return the delta if it could be calculated
      */
     public abstract Optional<Delta> calculateDelta(Run<?, ?> build, Run<?, ?> referenceBuild,
-            FilteredLog logger);
+            String scmKeyFilter, FilteredLog logger);
 
     /**
      * A delta calculator that does nothing.
@@ -56,14 +43,8 @@ public abstract class DeltaCalculator implements Serializable {
         private static final long serialVersionUID = 1564285974889709821L;
 
         @Override
-        public Optional<Delta> calculateDelta(final String currentCommitId, final String referenceCommitId,
-                final FilteredLog logger) {
-            return Optional.empty();
-        }
-
-        @Override
         public Optional<Delta> calculateDelta(final Run<?, ?> build, final Run<?, ?> referenceBuild,
-                final FilteredLog logger) {
+                final String scmKeyFilter, final FilteredLog logger) {
             return Optional.empty();
         }
     }

--- a/src/test/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactoryITest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/DeltaCalculatorFactoryITest.java
@@ -49,8 +49,7 @@ public class DeltaCalculatorFactoryITest {
         DeltaCalculator nullCalculator = createDeltaCalculator("/", log);
 
         assertThat(nullCalculator).isInstanceOf(NullDeltaCalculator.class);
-        assertThat(nullCalculator.calculateDelta("", "", log)).isEmpty();
-        assertThat(nullCalculator.calculateDelta(mock(Run.class), mock(Run.class), log)).isEmpty();
+        assertThat(nullCalculator.calculateDelta(mock(Run.class), mock(Run.class), "", log)).isEmpty();
         assertThat(log.getInfoMessages()).containsOnly(NO_SUITABLE_DELTA_CALCULATOR_FOUND,
                 ACTUAL_FACTORY_NULL_DELTA_CALCULATOR, EMPTY_FACTORY_NULL_DELTA_CALCULATOR);
         assertThat(log.getErrorMessages()).isEmpty();
@@ -101,14 +100,8 @@ public class DeltaCalculatorFactoryITest {
         private static final long serialVersionUID = -2091805649078555383L;
 
         @Override
-        public Optional<Delta> calculateDelta(final String currentCommitId, final String referenceCommitId,
-                final FilteredLog logger) {
-            return Optional.empty();
-        }
-
-        @Override
         public Optional<Delta> calculateDelta(final Run<?, ?> build, final Run<?, ?> referenceBuild,
-                final FilteredLog logger) {
+                final String scmFilterKey, final FilteredLog logger) {
             return Optional.empty();
         }
     }


### PR DESCRIPTION
I adjusted the code delta API so that the delta is calculated dependent on a passed SCM key filter in case that multiple SCMs are in use.
