### PR TITLE
Store old file name for processing file renames

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,18 @@
                   <justification>This API is not finally in use yet.</justification>
                 </item>
                 <item>
+                  <code>java.field.serialVersionUIDUnchanged</code>
+                  <classSimpleName>FileChanges</classSimpleName>
+                  <justification>This API is not finally in use yet.</justification>
+                </item>
+                <item>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <package>io.jenkins.plugins.forensics.delta.model</package>
+                  <classSimpleName>FileChanges</classSimpleName>
+                  <elementKind>constructor</elementKind>
+                  <justification>The additional parameter is required for processing renamed files.</justification>
+                </item>
+                <item>
                   <code>java.method.numberOfParametersChanged</code>
                   <package>io.jenkins.plugins.forensics.delta</package>
                   <methodName>calculateDelta</methodName>

--- a/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
+++ b/src/main/java/io/jenkins/plugins/forensics/delta/model/FileChanges.java
@@ -20,6 +20,7 @@ public class FileChanges implements Serializable {
     private static final long serialVersionUID = 6135245877389921937L;
 
     private final String fileName;
+    private final String oldFileName;
 
     private final String fileContent;
 
@@ -38,6 +39,8 @@ public class FileChanges implements Serializable {
      *
      * @param fileName
      *         The name of the file
+     * @param oldFileName
+     *         The old file name before the edit
      * @param fileContent
      *         The content of the file
      * @param fileEditType
@@ -45,9 +48,10 @@ public class FileChanges implements Serializable {
      * @param changes
      *         The changes made to the file
      */
-    public FileChanges(final String fileName, final String fileContent, final FileEditType fileEditType,
-            final Map<ChangeEditType, Set<Change>> changes) {
+    public FileChanges(final String fileName, final String oldFileName, final String fileContent,
+            final FileEditType fileEditType, final Map<ChangeEditType, Set<Change>> changes) {
         this.fileName = fileName;
+        this.oldFileName = oldFileName;
         this.fileContent = fileContent;
         this.fileEditType = fileEditType;
         this.changes = new HashMap<>(changes);
@@ -55,6 +59,10 @@ public class FileChanges implements Serializable {
 
     public String getFileName() {
         return fileName;
+    }
+
+    public String getOldFileName() {
+        return oldFileName;
     }
 
     public String getFileContent() {
@@ -110,6 +118,7 @@ public class FileChanges implements Serializable {
         }
         FileChanges that = (FileChanges) o;
         return Objects.equals(fileName, that.fileName)
+                && Objects.equals(oldFileName, that.oldFileName)
                 && Objects.equals(fileContent, that.fileContent)
                 && fileEditType == that.fileEditType
                 && Objects.equals(changes, that.changes);
@@ -117,6 +126,6 @@ public class FileChanges implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(fileName, fileContent, fileEditType, changes);
+        return Objects.hash(fileName, oldFileName, fileContent, fileEditType, changes);
     }
 }

--- a/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/delta/model/FileChangesTest.java
@@ -19,6 +19,7 @@ import static io.jenkins.plugins.forensics.assertions.Assertions.*;
 class FileChangesTest {
 
     private static final String FILE_NAME = "test";
+    private static final String OLD_FILE_NAME = "testOld";
     private static final String FILE_CONTENT = "test";
     private static final FileEditType FILE_EDIT_TYPE = FileEditType.ADD;
     private static final Map<ChangeEditType, Set<Change>> FILE_CHANGES = Collections.emptyMap();
@@ -27,6 +28,7 @@ class FileChangesTest {
     void testFileChangesGetter() {
         FileChanges fileChanges = createFileChanges();
         assertThat(fileChanges.getFileName()).isEqualTo(FILE_NAME);
+        assertThat(fileChanges.getOldFileName()).isEqualTo(OLD_FILE_NAME);
         assertThat(fileChanges.getFileContent()).isEqualTo(FILE_CONTENT);
         assertThat(fileChanges.getFileEditType()).isEqualTo(FILE_EDIT_TYPE);
         assertThat(fileChanges.getChanges()).isEqualTo(FILE_CHANGES);
@@ -67,6 +69,6 @@ class FileChangesTest {
      * @return the created instance
      */
     private FileChanges createFileChanges() {
-        return new FileChanges(FILE_NAME, FILE_CONTENT, FILE_EDIT_TYPE, FILE_CHANGES);
+        return new FileChanges(FILE_NAME, OLD_FILE_NAME, FILE_CONTENT, FILE_EDIT_TYPE, FILE_CHANGES);
     }
 }


### PR DESCRIPTION
I added an attribute to `FileChanges` in order to store the file path before a rename.
