### PR TITLE
Use hashCode as `ID`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <url>https://github.com/jenkinsci/forensics-api-plugin</url>
 
   <properties>
-    <revision>1.16.0</revision>
+    <revision>1.15.1</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.forensics.api</module.name>

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/CommitStatisticsBuildAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/CommitStatisticsBuildAction/summary.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
 
   <t:summary icon="/plugin/forensics-api/icons/diff-stat.svg">
-    <span id="commits-statistics-of-${it.scmKey}">
+    <span id="commits-statistics-of-${it.scmKey.hashCode()}">
       ${%title}: ${it.scmKey}
       <j:set var="s" value="${it.commitStatistics}"/>
       <ul>

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/ForensicsBuildAction/summary.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
 
   <t:summary icon="/plugin/forensics-api/icons/forensics.svg">
-    <span id="scm-forensics-of-${it.scmKey}">
+    <span id="scm-forensics-of-${it.scmKey.hashCode()}">
       ${%title}: ${it.scmKey}
       <j:set var="s" value="${it.result.latestStatistics}"/>
       <ul>


### PR DESCRIPTION
Use the `hashCode` of SCM as ID to avoid illegal characters in ID.