### PR TITLE
Use HTTPS SCM URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
   </build>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/forensics-api-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/forensics-api-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/forensics-api-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/forensics-api-plugin</url>
     <tag>${scmTag}</tag>


### PR DESCRIPTION
The old protocol is [deprecated](https://github.blog/2021-09-01-improving-git-protocol-security-github/).