### PR TITLE
Make trend charts theme-aware

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>echarts-api</artifactId>
-      <version>5.4.0-4-rc820.fc605555db_b_c</version>
+      <version>5.4.0-4</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>echarts-api</artifactId>
-      <version>5.4.0-4-rc815.a_ff2e0060885</version>
+      <version>5.4.0-4-rc819.ef2a_8d3f99c8</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>echarts-api</artifactId>
+      <version>5.4.0-4-rc815.a_ff2e0060885</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>echarts-api</artifactId>
-      <version>5.4.0-4-rc819.ef2a_8d3f99c8</version>
+      <version>5.4.0-4-rc820.fc605555db_b_c</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/src/main/java/io/jenkins/plugins/forensics/miner/AddedVersusDeletedLinesTrendChart.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/AddedVersusDeletedLinesTrendChart.java
@@ -8,8 +8,9 @@ import edu.hm.hafner.echarts.LineSeries.FilledMode;
 import edu.hm.hafner.echarts.LineSeries.StackedMode;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
 import edu.hm.hafner.echarts.SeriesBuilder;
+
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 /**
  * Builds the Java side model for a trend chart showing the number of deleted and added lines of code in a build.
@@ -42,9 +43,9 @@ class AddedVersusDeletedLinesTrendChart {
         LinesDataSet dataSet = seriesBuilder.createDataSet(configuration, results);
 
         LinesChartModel model = new LinesChartModel(dataSet);
-        LineSeries newSeries = getSeries(dataSet, "Added Lines", Palette.GREEN,
+        LineSeries newSeries = getSeries(dataSet, "Added Lines", JenkinsPalette.GREEN,
                 AddedVersusDeletedLinesForensicsSeriesBuilder.ADDED);
-        LineSeries fixedSeries = getSeries(dataSet, "Deleted Lines", Palette.RED,
+        LineSeries fixedSeries = getSeries(dataSet, "Deleted Lines", JenkinsPalette.RED,
                 AddedVersusDeletedLinesForensicsSeriesBuilder.DELETED);
 
         model.addSeries(newSeries, fixedSeries);
@@ -53,8 +54,8 @@ class AddedVersusDeletedLinesTrendChart {
     }
 
     private LineSeries getSeries(final LinesDataSet dataSet,
-            final String name, final Palette color, final String dataSetId) {
-        LineSeries newSeries = new LineSeries(name, color.getNormal(), StackedMode.SEPARATE_LINES, FilledMode.FILLED);
+            final String name, final JenkinsPalette color, final String dataSetId) {
+        LineSeries newSeries = new LineSeries(name, color.normal(), StackedMode.SEPARATE_LINES, FilledMode.FILLED);
         newSeries.addAll(dataSet.getSeries(dataSetId));
         return newSeries;
     }

--- a/src/main/java/io/jenkins/plugins/forensics/miner/CodeMetricTrendChart.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/CodeMetricTrendChart.java
@@ -8,7 +8,8 @@ import edu.hm.hafner.echarts.LineSeries.FilledMode;
 import edu.hm.hafner.echarts.LineSeries.StackedMode;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
+
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 /**
  * Builds the Java side model for a trend chart showing the total number of lines of code and churn for all files in the
@@ -38,11 +39,11 @@ class CodeMetricTrendChart {
         LinesDataSet dataSet = builder.createDataSet(configuration, results);
 
         LinesChartModel model = new LinesChartModel(dataSet);
-        Palette[] colors = {Palette.BLUE, Palette.ORANGE};
+        JenkinsPalette[] colors = {JenkinsPalette.BLUE, JenkinsPalette.ORANGE};
         int index = 0;
         for (String name : dataSet.getDataSetIds()) {
             int colorIndex = (index++) % colors.length;
-            LineSeries series = new LineSeries(name, colors[colorIndex].getNormal(),
+            LineSeries series = new LineSeries(name, colors[colorIndex].normal(),
                     StackedMode.SEPARATE_LINES, FilledMode.LINES);
             series.addAll(dataSet.getSeries(name));
             model.addSeries(series);

--- a/src/main/java/io/jenkins/plugins/forensics/miner/FileDetailsView.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/FileDetailsView.java
@@ -15,7 +15,6 @@ import edu.hm.hafner.echarts.LineSeries.FilledMode;
 import edu.hm.hafner.echarts.LineSeries.StackedMode;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
 
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 import hudson.model.ModelObject;
@@ -25,6 +24,7 @@ import io.jenkins.plugins.datatables.DefaultAsyncTableContentProvider;
 import io.jenkins.plugins.datatables.TableColumn;
 import io.jenkins.plugins.datatables.TableModel;
 import io.jenkins.plugins.echarts.AsyncTrendChart;
+import io.jenkins.plugins.echarts.JenkinsPalette;
 import io.jenkins.plugins.forensics.util.CommitDecorator;
 
 /**
@@ -197,10 +197,10 @@ public class FileDetailsView extends DefaultAsyncTableContentProvider implements
 
             LinesChartModel model = new LinesChartModel(dataSet);
             model.setDomainAxisItemName("Commit");
-            LineSeries added = new LineSeries(Messages.TrendChart_Churn_Legend_Added(), Palette.GREEN.getNormal(),
+            LineSeries added = new LineSeries(Messages.TrendChart_Churn_Legend_Added(), JenkinsPalette.GREEN.normal(),
                     StackedMode.SEPARATE_LINES, FilledMode.FILLED);
             added.addAll(dataSet.getSeries(ADDED_KEY));
-            LineSeries deleted = new LineSeries(Messages.TrendChart_Churn_Legend_Deleted(), Palette.RED.getNormal(),
+            LineSeries deleted = new LineSeries(Messages.TrendChart_Churn_Legend_Deleted(), JenkinsPalette.RED.normal(),
                     StackedMode.SEPARATE_LINES, FilledMode.FILLED);
             deleted.addAll(dataSet.getSeries(DELETED_KEY));
 

--- a/src/main/java/io/jenkins/plugins/forensics/miner/FilesCountTrendChart.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/FilesCountTrendChart.java
@@ -8,7 +8,8 @@ import edu.hm.hafner.echarts.LineSeries.FilledMode;
 import edu.hm.hafner.echarts.LineSeries.StackedMode;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
+
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 /**
  * Builds the Java side model for a trend chart showing the number of files in the repository. The trend chart contains
@@ -37,7 +38,7 @@ class FilesCountTrendChart {
         LinesDataSet dataSet = builder.createDataSet(configuration, results);
 
         LinesChartModel model = new LinesChartModel(dataSet);
-        LineSeries series = new LineSeries(Messages.TrendChart_Files_Legend_Label(), Palette.BLUE.getNormal(),
+        LineSeries series = new LineSeries(Messages.TrendChart_Files_Legend_Label(), JenkinsPalette.BLUE.normal(),
                 StackedMode.SEPARATE_LINES, FilledMode.FILLED);
         if (dataSet.getDomainAxisSize() > 0) {
             series.addAll(dataSet.getSeries(FilesCountSeriesBuilder.TOTALS_KEY));

--- a/src/main/java/io/jenkins/plugins/forensics/miner/RelativeCountTrendChart.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/RelativeCountTrendChart.java
@@ -8,8 +8,9 @@ import edu.hm.hafner.echarts.LineSeries.FilledMode;
 import edu.hm.hafner.echarts.LineSeries.StackedMode;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
 import edu.hm.hafner.echarts.SeriesBuilder;
+
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 /**
  * Builds the Java side model for a trend chart showing the number modified files, commits and authors in the
@@ -41,11 +42,11 @@ class RelativeCountTrendChart {
         LinesDataSet dataSet = seriesBuilder.createDataSet(configuration, results);
         LinesChartModel model = new LinesChartModel(dataSet);
         if (dataSet.getDomainAxisSize() > 0) {
-            LineSeries authors = getSeries(dataSet, "Authors", Palette.BLUE,
+            LineSeries authors = getSeries(dataSet, "Authors", JenkinsPalette.BLUE,
                     RelativeCountForensicsSeriesBuilder.AUTHORS_KEY);
-            LineSeries commits = getSeries(dataSet, "Commits", Palette.GREEN,
+            LineSeries commits = getSeries(dataSet, "Commits", JenkinsPalette.GREEN,
                     RelativeCountForensicsSeriesBuilder.COMMITS_KEY);
-            LineSeries files = getSeries(dataSet, "Modified files", Palette.ORANGE,
+            LineSeries files = getSeries(dataSet, "Modified files", JenkinsPalette.ORANGE,
                     RelativeCountForensicsSeriesBuilder.FILES_KEY);
 
             model.addSeries(authors, commits, files);
@@ -55,8 +56,8 @@ class RelativeCountTrendChart {
     }
 
     private LineSeries getSeries(final LinesDataSet dataSet,
-            final String name, final Palette color, final String dataSetId) {
-        LineSeries series = new LineSeries(name, color.getNormal(), StackedMode.SEPARATE_LINES, FilledMode.LINES);
+            final String name, final JenkinsPalette color, final String dataSetId) {
+        LineSeries series = new LineSeries(name, color.normal(), StackedMode.SEPARATE_LINES, FilledMode.LINES);
         series.addAll(dataSet.getSeries(dataSetId));
         return series;
     }

--- a/src/main/java/io/jenkins/plugins/forensics/miner/SizePieChart.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/SizePieChart.java
@@ -5,9 +5,10 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.function.Function;
 
-import edu.hm.hafner.echarts.Palette;
 import edu.hm.hafner.echarts.PieChartModel;
 import edu.hm.hafner.echarts.PieData;
+
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 /**
  * Builds the model for a pie chart showing the distribution of issues by a configurable {@code size} property of the
@@ -41,7 +42,7 @@ class SizePieChart {
         }
         int color = 0;
         for (Entry<Integer, Integer> entry : distribution.entrySet()) {
-            model.add(new PieData("< " + entry.getKey(), entry.getValue()), Palette.color(color++));
+            model.add(new PieData("< " + entry.getKey(), entry.getValue()), JenkinsPalette.chartColor(color++).normal());
         }
         return model;
     }

--- a/src/test/java/io/jenkins/plugins/forensics/miner/FilesCountTrendChartTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/miner/FilesCountTrendChartTest.java
@@ -9,7 +9,8 @@ import edu.hm.hafner.echarts.BuildResult;
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.LineSeries;
 import edu.hm.hafner.echarts.LinesChartModel;
-import edu.hm.hafner.echarts.Palette;
+
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 import static io.jenkins.plugins.forensics.miner.ResultStubs.*;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
@@ -30,7 +31,7 @@ class FilesCountTrendChartTest {
 
         LinesChartModel model = chart.create(results, new ChartModelConfiguration());
 
-        verifySeries(model.getSeries().get(0), Palette.BLUE, Messages.TrendChart_Files_Legend_Label(), 10, 20);
+        verifySeries(model.getSeries().get(0), JenkinsPalette.BLUE, Messages.TrendChart_Files_Legend_Label(), 10, 20);
 
         assertThatJson(model).node("domainAxisLabels")
                 .isArray().hasSize(2)
@@ -43,8 +44,8 @@ class FilesCountTrendChartTest {
                 .isArray().hasSize(2).containsExactly(10, 20);
     }
 
-    private void verifySeries(final LineSeries series, final Palette normalColor, final String newVersusFixedSeriesBuilderName, final int... values) {
-        assertThatJson(series).node("itemStyle").node("color").isEqualTo(normalColor.getNormal());
+    private void verifySeries(final LineSeries series, final JenkinsPalette normalColor, final String newVersusFixedSeriesBuilderName, final int... values) {
+        assertThatJson(series).node("itemStyle").node("color").isEqualTo(normalColor.normal());
         assertThatJson(series).node("name").isEqualTo(newVersusFixedSeriesBuilderName);
         for (int value : values) {
             assertThatJson(series).node("data").isArray().hasSize(values.length).contains(value);


### PR DESCRIPTION
Use colors from the new Echarts `JenkinsPalette` for trend charts.

Downstream PR of https://github.com/jenkinsci/echarts-api-plugin/pull/287.

![Bildschirmfoto 2023-05-15 um 21 35 12](https://github.com/jenkinsci/forensics-api-plugin/assets/503338/be56d89d-3556-438f-8d83-a4ca0dc9a955)
