### PR TITLE
[JENKINS-73380] Add option to consider running builds as reference

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceJobModelValidation.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/ReferenceJobModelValidation.java
@@ -10,7 +10,7 @@ import hudson.util.FormValidation;
 import io.jenkins.plugins.util.JenkinsFacade;
 
 /**
- * Validates all properties of a configuration of a reference job.
+ * Validates all properties of a reference job configuration.
  *
  * @author Ullrich Hafner
  */

--- a/src/main/resources/io/jenkins/plugins/forensics/miner/RepositoryMinerStep/help-scm.html
+++ b/src/main/resources/io/jenkins/plugins/forensics/miner/RepositoryMinerStep/help-scm.html
@@ -1,0 +1,5 @@
+<div>
+    Specify the key of your repository (substring is sufficient) if you are using multiple SCMs in your job.
+    When your job is composed of several SCM checkouts (modules, pipeline libraries, etc.) then Jenkins stores
+    all those repositories in an unsorted way.
+</div>

--- a/src/main/resources/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder/config.jelly
@@ -1,11 +1,14 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
-  <f:entry title="${%title.referenceJob}" field="referenceJob" description="${%description.referenceJob}">
+  <f:entry title="${%title.referenceJob}" field="referenceJob" >
     <f:combobox />
   </f:entry>
-  <f:entry title="${%title.requiredResult}" field="requiredResult" description="${%description.requiredResult}">
+  <f:entry title="${%title.requiredResult}" field="requiredResult" >
     <f:select />
+  </f:entry>
+  <f:entry title="${%title.considerRunningBuild}" field="considerRunningBuild">
+    <f:checkbox />
   </f:entry>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder/config.properties
+++ b/src/main/resources/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder/config.properties
@@ -1,4 +1,3 @@
 title.referenceJob=Reference Job
-description.referenceJob=Select the baseline job to create relative build reports.
 title.requiredResult=Required Build Result
-description.requiredResult=Consider only builds with this result as reference builds.
+title.considerRunningBuild=Consider running builds as reference

--- a/src/main/resources/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder/help-considerRunningBuild.html
+++ b/src/main/resources/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder/help-considerRunningBuild.html
@@ -1,0 +1,3 @@
+If enabled, then running builds will be considered as reference build as well. Otherwise, only completed builds
+are considered. Enabling this option might cause problems if the reference build has not yet all the
+required results available.


### PR DESCRIPTION
In some rare cases it might make sense to select a reference build that is not yet complete. In those cases the pipeline must ensure that the required build results are already available.

See [JENKINS-73380](https://issues.jenkins.io/browse/JENKINS-73380).