### PR TITLE
[JENKINS-73380] Make sure that any existing reference build action is removed

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder.java
@@ -172,6 +172,11 @@ public class SimpleReferenceRecorder extends Recorder implements SimpleBuildStep
             @NonNull final Launcher launcher, @NonNull final TaskListener listener) {
         FilteredLog log = new FilteredLog("Errors while computing the reference build:");
 
+        var existing = run.removeActions(ReferenceBuild.class);
+        if (existing) {
+            log.logError("Replaced existing reference build, this typically indicates a misconfiguration "
+                    + "as the reference should be constant");
+        }
         run.addAction(findReferenceBuild(run, log));
 
         LogHandler logHandler = new LogHandler(listener, "ReferenceFinder");


### PR DESCRIPTION
Otherwise, there will be multiple reference build actions, but there must be only one that identifies the baseline. Log an error message if the action already exists since the baseline should be constant.

See [JENKINS-73380](https://issues.jenkins.io/browse/JENKINS-73380).