### PR TITLE
Disabling `ScmResolverTest.shouldResolveScmForPipelineWithFlowNode`

### DIFF
--- a/src/test/java/io/jenkins/plugins/forensics/util/ScmResolverTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/util/ScmResolverTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.assertj.core.api.ObjectAssert;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
@@ -117,6 +118,7 @@ class ScmResolverTest {
         return first;
     }
 
+    @Disabled("TODO rewrite to use JenkinsRule, not Mockito")
     @Test
     void shouldResolveScmForPipelineWithFlowNode() throws IOException {
         WorkflowJob pipeline = createPipeline();


### PR DESCRIPTION
CloudBees CI PCT runs indicate that this is broken by https://github.com/jenkinsci/jenkins/pull/10042. Even on the current core version, it prints numerous stack traces because code is trying to run which cannot work in a Mockito-based environment. Please do not use Mockito to write tests for Jenkins plugins; it causes unnecessary maintenance burdens for others. I could not easily confirm the behavior directly on current core versions because of the use of the nonstandard `analysis-pom` parent POM; please use the standard parent instead (this is also a source of difficulty for the Jenkins community).