### PR TITLE
[JENKINS-75429] Ignore the case of the SCM when matching the SCM repository parameter

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/util/ScmResolver.java
+++ b/src/main/java/io/jenkins/plugins/forensics/util/ScmResolver.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins.forensics.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,7 +57,7 @@ public class ScmResolver {
     public Collection<? extends SCM> getScms(final Run<?, ?> run, final String keyFilter) {
         return getScms(run)
                 .stream()
-                .filter(r -> r.getKey().contains(keyFilter))
+                .filter(r -> StringUtils.containsIgnoreCase(r.getKey(), keyFilter))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Improve the selection of the correct SCM (see [JENKINS-75429](https://issues.jenkins.io/browse/JENKINS-75429)). It makes sense to ignore the capitalization of the name as it is not relevant on Windows.

Supersedes #587 