### PR TITLE
Use BOM versions for all dependencies marked with a TODO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <!-- TODO: remove the version when a matching BOM is available -->
-      <version>6.0.0</version>
     </dependency>
 
     <!-- Jenkins Plugin Dependencies -->


### PR DESCRIPTION
Jenkins BOM contains all correct versions again.