### PR TITLE
[JENKINS-76020] Resolve missing architecture rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>6.1157.vc75ef7129d86</version>
+      <version>6.1167.v022176c7e0ca_</version>
     </dependency>
 
     <!-- Jenkins Plugin Dependencies -->
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>6.1157.vc75ef7129d86</version>
+      <version>6.1167.v022176c7e0ca_</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>6.1157.vc75ef7129d86</version>
     </dependency>
 
     <!-- Jenkins Plugin Dependencies -->
@@ -105,6 +106,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>6.1157.vc75ef7129d86</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/io/jenkins/plugins/archunit/PluginArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/archunit/PluginArchitectureTest.java
@@ -4,7 +4,7 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-import edu.hm.hafner.util.ArchitectureRules;
+import edu.hm.hafner.archunit.ArchitectureRules;
 
 import io.jenkins.plugins.util.PluginArchitectureRules;
 


### PR DESCRIPTION
Bump the version of plugin-util to 6.1165.v322e76215b_a_4. This version contains the missing class again.