### PR TITLE
Fix sorting of filename column

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsTableModel.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsTableModel.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.jenkins.plugins.datatables.DetailedCell;
 import io.jenkins.plugins.datatables.TableColumn;
 import io.jenkins.plugins.datatables.TableColumn.ColumnBuilder;
 import io.jenkins.plugins.datatables.TableColumn.ColumnCss;
@@ -50,6 +51,7 @@ public class ForensicsTableModel extends TableModel {
         var builder = new ColumnBuilder();
 
         columns.add(builder.withHeaderLabel(Messages.Table_Column_File())
+                .withDetailedCell()
                 .withDataPropertyKey("fileName")
                 .withHeaderClass(ColumnCss.NONE)
                 .build());
@@ -98,18 +100,19 @@ public class ForensicsTableModel extends TableModel {
 
         /**
          * SHows the file name column: the column shows the name without the path. The full path is shown
-         * as additional tooltip.
+         * as an additional tooltip.
          *
          * @return the file name column (as HTML a tag)
          */
-        public String getFileName() {
+        public DetailedCell<?> getFileName() {
             var fullPath = fileStatistics.getFileName();
-
-            return a().withHref("fileName." + fullPath.hashCode())
-                    .withText(FilenameUtils.getName(fullPath))
+            var fileName = FilenameUtils.getName(fullPath);
+            var link = a().withHref("fileName." + fullPath.hashCode())
+                    .withText(fileName)
                     .attr("data-bs-toggle", "tooltip")
                     .attr("data-bs-placement", "left")
                     .withTitle(fullPath).render();
+            return new DetailedCell<>(link, fileName);
         }
 
         public int getAuthorsSize() {

--- a/src/test/java/io/jenkins/plugins/forensics/miner/ForensicsTableModelTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/miner/ForensicsTableModelTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.forensics.miner;
 
 import org.junit.jupiter.api.Test;
 
+import io.jenkins.plugins.datatables.DetailedCell;
 import io.jenkins.plugins.datatables.TableColumn;
 import io.jenkins.plugins.forensics.miner.ForensicsTableModel.ForensicsRow;
 
@@ -64,14 +65,18 @@ class ForensicsTableModelTest {
         when(fileStatisticsStub.getLinesOfCode()).thenReturn(5);
         when(fileStatisticsStub.getAbsoluteChurn()).thenReturn(6);
 
+        var fileName = "<a href=\"fileName.-734768633\" data-bs-toggle=\"tooltip\" data-bs-placement=\"left\" title=\"filename\">filename</a>";
         assertThat(forensicsRow)
-                .hasFileName(
-                        "<a href=\"fileName.-734768633\" data-bs-toggle=\"tooltip\" data-bs-placement=\"left\" title=\"filename\">filename</a>")
                 .hasAuthorsSize(1)
                 .hasCommitsSize(2)
                 .hasModifiedAt(3)
                 .hasAddedAt(4)
                 .hasLinesOfCode(5)
                 .hasChurn(6);
+        assertThat(forensicsRow.getFileName()).isInstanceOfSatisfying(DetailedCell.class,
+                cell -> {
+                    assertThat(cell.getDisplay()).isEqualTo(fileName);
+                    assertThat(cell.getSort()).isEqualTo("filename");
+                });
     }
 }


### PR DESCRIPTION
Filenames need to be represented by a `DetailsCell` so we can have different properties for display and sort.
