### PR TITLE
Fix rendering of columns in forensics table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>data-tables-api</artifactId>
+      <version>2.3.7-1554.v6113418a_6935</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsTableModel.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsTableModel.java
@@ -56,6 +56,7 @@ public class ForensicsTableModel extends TableModel {
                 .withHeaderClass(ColumnCss.NONE)
                 .build());
         columns.add(builder.withHeaderLabel(Messages.Table_Column_AuthorsSize())
+                .withPlainValueCell()
                 .withDataPropertyKey("authorsSize")
                 .withHeaderClass(ColumnCss.NONE)
                 .build());
@@ -99,8 +100,8 @@ public class ForensicsTableModel extends TableModel {
         }
 
         /**
-         * SHows the file name column: the column shows the name without the path. The full path is shown
-         * as an additional tooltip.
+         * Shows the file name column: the column shows the name without the path. The full path is shown as an
+         * additional tooltip.
          *
          * @return the file name column (as HTML a tag)
          */

--- a/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsViewModel.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/ForensicsViewModel.java
@@ -1,9 +1,9 @@
 package io.jenkins.plugins.forensics.miner;
 
+import edu.hm.hafner.echarts.JacksonFacade;
+
 import java.io.IOException;
 import java.util.NoSuchElementException;
-
-import edu.hm.hafner.echarts.JacksonFacade;
 
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
@@ -87,16 +87,16 @@ public class ForensicsViewModel extends DefaultAsyncTableContentProvider impleme
     }
 
     /**
-     * Returns a new sub page for the selected link.
+     * Returns a new subpage for the selected link.
      *
      * @param link
-     *         the link to identify the sub page to show
+     *         the link to identify the subpage to show
      * @param request
      *         Stapler request
      * @param response
      *         Stapler response
      *
-     * @return the new sub page
+     * @return the new subpage
      */
     @SuppressWarnings("unused") //called by jelly view
     public Object getDynamic(final String link, final StaplerRequest2 request, final StaplerResponse2 response) {

--- a/src/test/java/io/jenkins/plugins/forensics/miner/ForensicsTableModelTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/miner/ForensicsTableModelTest.java
@@ -7,6 +7,7 @@ import io.jenkins.plugins.datatables.TableColumn;
 import io.jenkins.plugins.forensics.miner.ForensicsTableModel.ForensicsRow;
 
 import static io.jenkins.plugins.forensics.assertions.Assertions.*;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
 import static org.mockito.Mockito.*;
 
 class ForensicsTableModelTest {
@@ -29,6 +30,14 @@ class ForensicsTableModelTest {
                         Messages.Table_Column_LOC(),
                         Messages.Table_Column_Churn()
                 );
+        assertThatJson(tableModel.getColumns().get(0).getDefinition()).node("render")
+                .isEqualTo("""
+                        {
+                          "_" : "display",
+                          "sort": "sort"
+                        }
+                        """);
+        assertThatJson(tableModel.getColumns().get(1).getDefinition()).node("render").isAbsent();
     }
 
     @Test


### PR DESCRIPTION
The column builder was not reset to its initial values and caused all columns to be detailed columns.