### PR TITLE
Declare jackson2-api and jackson-annotations2-api test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,21 @@
       <artifactId>pipeline-model-definition</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- assertThatJson uses Jackson 2, declare dependency for tests -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <scope>test</scope>
+      <!-- TODO - remove version declaration when in plugin BOM -->
+      <version>2.21.2-436.v29efdb_7418ff</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jackson-annotations2-api</artifactId>
+      <scope>test</scope>
+      <!-- TODO - remove version declaration when in plugin BOM -->
+      <version>2.21-7.v4777a_f3a_a_d47</version>
+    </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>


### PR DESCRIPTION
## Declare jackson2-api and jackson-annotations2-api test dependency

The jackson2-api plugin and jackson3-api plugin were both bundling a copy of the jackson-annotation jar file.  That caused class loading issues as reported in:

* https://github.com/jenkinsci/jackson3-api-plugin/issues/41
* https://issues.jenkins.io/browse/JENKINS-76435
* https://issues.jenkins.io/browse/JENKINS-76437

New releases of the jackson2-api plugin and jackson3-api plugin now depend on the jackson-annotations2-api plugin.  They were released after merging pull requests:

* https://github.com/jenkinsci/jackson2-api-plugin/pull/336
* https://github.com/jenkinsci/jackson3-api-plugin/pull/42

One of the test classes in this plugin uses assertThatJson.  It has a transitive dependency on jackson2-api that was previously satisfied through the echarts API or through other plugins that were loading Jackson 2.  Unfortunately, that test dependency now needs to be declared explicitly.

cc: @darinpope

We'll need a new release of the plugin so that the tests pass in plugin BOM.  We'll temporarily exclude the failing tests in plugin BOM until a new release of the plugin is available that includes this pull request.

### Testing done

* Confirmed that tests pass locally
* Confirmed that tests pass in plugin BOM

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
