### PR TITLE
Revert version of j2html to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>7.1328.v9b_cc5d0c1c14</version>
+      <version>7.1330.v47b_46ee2047a_</version>
     </dependency>
 
     <!-- Jenkins Plugin Dependencies -->
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>7.1328.v9b_cc5d0c1c14</version>
+      <version>7.1330.v47b_46ee2047a_</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Versions starting from 1.5.0 are not backward-compatible anymore.
