### PR TITLE
Allow `discoverReferenceBuild` to run on Agent none

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder.java
+++ b/src/main/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorder.java
@@ -178,14 +178,36 @@ public class SimpleReferenceRecorder extends Recorder implements SimpleBuildStep
         return BuildStepMonitor.NONE;
     }
 
+    /**
+     * Returns {@code false} so that this step can be used in pipelines with {@code agent none} or without any
+     * workspace allocation. The step only queries job/build history and does not need access to the workspace.
+     *
+     * @return {@code false}
+     */
+    @Override
+    public boolean requiresWorkspace() {
+        return false;
+    }
+
     @Override
     public SimpleReferenceRecorderDescriptor getDescriptor() {
         return (SimpleReferenceRecorderDescriptor) super.getDescriptor();
     }
 
+    /**
+     * Discovers the reference build without requiring a workspace. This is the primary entry-point used when the
+     * step is executed with {@code agent none}.
+     *
+     * @param run
+     *         the current build
+     * @param env
+     *         the environment variables
+     * @param listener
+     *         the task listener
+     */
     @Override
-    public void perform(@NonNull final Run<?, ?> run, @NonNull final FilePath workspace, @NonNull final EnvVars env,
-            @NonNull final Launcher launcher, @NonNull final TaskListener listener) {
+    public void perform(@NonNull final Run<?, ?> run, @NonNull final EnvVars env,
+            @NonNull final TaskListener listener) {
         var log = new FilteredLog("Errors while computing the reference build:");
 
         var existing = run.removeActions(ReferenceBuild.class);
@@ -197,6 +219,27 @@ public class SimpleReferenceRecorder extends Recorder implements SimpleBuildStep
 
         var logHandler = new LogHandler(listener, "ReferenceFinder");
         logHandler.log(log);
+    }
+
+    /**
+     * Discovers the reference build. Delegates to {@link #perform(Run, EnvVars, TaskListener)} since no workspace
+     * is required.
+     *
+     * @param run
+     *         the current build
+     * @param workspace
+     *         the workspace (not used)
+     * @param env
+     *         the environment variables
+     * @param launcher
+     *         the launcher (not used)
+     * @param listener
+     *         the task listener
+     */
+    @Override
+    public void perform(@NonNull final Run<?, ?> run, @NonNull final FilePath workspace, @NonNull final EnvVars env,
+            @NonNull final Launcher launcher, @NonNull final TaskListener listener) {
+        perform(run, env, listener);
     }
 
     /**

--- a/src/test/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorderITest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorderITest.java
@@ -150,6 +150,57 @@ class SimpleReferenceRecorderITest extends IntegrationTestWithJenkinsPerSuite {
     }
 
     @Test
+    @Issue("JENKINS-699")
+    void shouldRunInDeclarativePipelineWithAgentNone() {
+        var reference = createPipeline();
+        reference.setDefinition(createPipelineScript(
+                """
+                node {
+                    echo 'Hello from reference job'
+                }
+                """));
+        Run<?, ?> baseline = buildWithResult(reference, Result.SUCCESS);
+
+        var job = createPipeline();
+        job.setDefinition(createPipelineScript(
+                "pipeline {\n"
+                        + "    agent none\n"
+                        + "    stages {\n"
+                        + "        stage ('Discover reference build') {\n"
+                        + "            steps {\n"
+                        + discoverReferenceJob(reference.getName())
+                        + "            }\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}"));
+        Run<?, ?> current = buildSuccessfully(job);
+
+        assertThat(findReferenceBuild(current)).contains(baseline);
+        assertThat(getConsoleLog(current))
+                .doesNotContain("Attempted to execute a step that requires a node context while 'agent none' was specified");
+    }
+
+    @Test
+    @Issue("JENKINS-699")
+    void shouldRunInScriptedPipelineWithoutNode() {
+        var reference = createPipeline();
+        reference.setDefinition(createPipelineScript(
+                """
+                node {
+                    echo 'Hello from reference job'
+                }
+                """));
+        Run<?, ?> baseline = buildWithResult(reference, Result.SUCCESS);
+
+        var job = createPipeline();
+        job.setDefinition(createPipelineScript(
+                discoverReferenceJob(reference.getName())));
+        Run<?, ?> current = buildSuccessfully(job);
+
+        assertThat(findReferenceBuild(current)).contains(baseline);
+    }
+
+    @Test
     void shouldRunInDeclarativePipeline() {
         var job = createPipeline();
 

--- a/src/test/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorderTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/reference/SimpleReferenceRecorderTest.java
@@ -23,6 +23,13 @@ import static org.mockito.Mockito.*;
 
 class SimpleReferenceRecorderTest {
     @Test
+    void shouldNotRequireWorkspace() {
+        var recorder = new SimpleReferenceRecorder();
+
+        assertThat(recorder.requiresWorkspace()).isFalse();
+    }
+
+    @Test
     void shouldFillModel() {
         var jenkins = mock(JenkinsFacade.class);
         var job = mock(BuildableItem.class);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Allow `discoverReferenceBuild` to run on Agent none

Fixes #699 
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
