### PR TITLE
Fix `RepositoryMinerStep`: match previous-build statistics by exact SCM key

### DIFF
--- a/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
+++ b/src/main/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStep.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.forensics.miner;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -109,7 +110,7 @@ public class RepositoryMinerStep extends Recorder implements SimpleBuildStep {
             RepositoryMiner miner = MinerFactory.findMiner(repository, run, workspace, listener, logger);
             logHandler.log(logger);
 
-            var repositoryStatistics = previousBuildStatistics(scm, run);
+            var repositoryStatistics = previousBuildStatistics(repository.getKey(), run);
             var addedRepositoryStatistics = miner.mine(repositoryStatistics, logger);
 
             logHandler.log(logger);
@@ -121,7 +122,8 @@ public class RepositoryMinerStep extends Recorder implements SimpleBuildStep {
         }
     }
 
-    private RepositoryStatistics previousBuildStatistics(final String repository, final Run<?, ?> run) {
+    @VisibleForTesting
+    RepositoryStatistics previousBuildStatistics(final String repository, final Run<?, ?> run) {
         for (Run<?, ?> build = run.getPreviousBuild(); build != null; build = build.getPreviousBuild()) {
             List<ForensicsBuildAction> actions = build.getActions(ForensicsBuildAction.class);
             if (!actions.isEmpty()) {

--- a/src/test/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStepTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/miner/RepositoryMinerStepTest.java
@@ -1,0 +1,165 @@
+package io.jenkins.plugins.forensics.miner;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.Issue;
+
+import java.util.Collections;
+import java.util.List;
+
+import hudson.model.Run;
+
+import io.jenkins.plugins.forensics.miner.FileStatistics.FileStatisticsBuilder;
+
+import static io.jenkins.plugins.forensics.assertions.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link RepositoryMinerStep}.
+ *
+ * @author Akash Manna
+ */
+class RepositoryMinerStepTest {
+    private static final String SCM_KEY = "git [https://github.com/jenkinsci/forensics-api-plugin]";
+    private static final String OTHER_SCM_KEY = "git [https://github.com/jenkinsci/git-forensics-plugin]";
+    private static final String EXISTING_FILE = "src/main/java/Foo.java";
+
+    @Test
+    @Issue("JENKINS-74804")
+    void shouldReturnCorrectStatisticsForEachScmKeyWithMultipleScms() {
+        var statisticsForFirstScm = new RepositoryStatistics();
+        statisticsForFirstScm.add(new FileStatisticsBuilder().build(EXISTING_FILE));
+
+        ForensicsBuildAction firstScmAction = createAction(SCM_KEY, statisticsForFirstScm);
+        ForensicsBuildAction secondScmAction = createAction(OTHER_SCM_KEY, new RepositoryStatistics());
+
+        var previousBuild = mock(Run.class);
+        when(previousBuild.getActions(ForensicsBuildAction.class))
+                .thenReturn(List.of(firstScmAction, secondScmAction));
+
+        var currentRun = mock(Run.class);
+        when(currentRun.getPreviousBuild()).thenReturn(previousBuild);
+
+        var step = new RepositoryMinerStep();
+
+        var resultForFirstScm = step.previousBuildStatistics(SCM_KEY, currentRun);
+        assertThat(resultForFirstScm).hasFiles(EXISTING_FILE);
+
+        var resultForSecondScm = step.previousBuildStatistics(OTHER_SCM_KEY, currentRun);
+        assertThat(resultForSecondScm).isEmpty();
+    }
+
+    @Test
+    @Issue("JENKINS-74804")
+    void shouldReturnStatisticsForEmptyScmKeyWhenSingleRepository() {
+        var statistics = new RepositoryStatistics();
+        statistics.add(new FileStatisticsBuilder().build(EXISTING_FILE));
+
+        ForensicsBuildAction action = createAction(SCM_KEY, statistics);
+
+        var previousBuild = mock(Run.class);
+        when(previousBuild.getActions(ForensicsBuildAction.class))
+                .thenReturn(List.of(action));
+
+        var currentRun = mock(Run.class);
+        when(currentRun.getPreviousBuild()).thenReturn(previousBuild);
+
+        var step = new RepositoryMinerStep();
+
+        var result = step.previousBuildStatistics("", currentRun);
+        assertThat(result).hasFiles(EXISTING_FILE);
+    }
+
+    @Test
+    @Issue("JENKINS-74804")
+    void shouldReturnEmptyStatisticsWhenNoPreviousBuildExists() {
+        var currentRun = mock(Run.class);
+        when(currentRun.getPreviousBuild()).thenReturn(null);
+
+        var step = new RepositoryMinerStep();
+        var result = step.previousBuildStatistics(SCM_KEY, currentRun);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @Issue("JENKINS-74804")
+    void shouldReturnEmptyStatisticsWhenPreviousBuildHasNoForensicsActions() {
+        var previousBuild = mock(Run.class);
+        when(previousBuild.getActions(ForensicsBuildAction.class))
+                .thenReturn(Collections.emptyList());
+        when(previousBuild.getPreviousBuild()).thenReturn(null);
+
+        var currentRun = mock(Run.class);
+        when(currentRun.getPreviousBuild()).thenReturn(previousBuild);
+
+        var step = new RepositoryMinerStep();
+        var result = step.previousBuildStatistics(SCM_KEY, currentRun);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @Issue("JENKINS-74804")
+    void shouldSkipBuildsWithNoForensicsActionsAndSearchFurther() {
+        var statisticsWithFiles = new RepositoryStatistics();
+        statisticsWithFiles.add(new FileStatisticsBuilder().build(EXISTING_FILE));
+
+        ForensicsBuildAction actionWithStats = createAction(SCM_KEY, statisticsWithFiles);
+
+        var buildWithActions = mock(Run.class);
+        when(buildWithActions.getActions(ForensicsBuildAction.class))
+                .thenReturn(List.of(actionWithStats));
+        when(buildWithActions.getPreviousBuild()).thenReturn(null);
+
+        var buildWithNoActions = mock(Run.class);
+        when(buildWithNoActions.getActions(ForensicsBuildAction.class))
+                .thenReturn(Collections.emptyList());
+        when(buildWithNoActions.getPreviousBuild()).thenReturn(buildWithActions);
+
+        var currentRun = mock(Run.class);
+        when(currentRun.getPreviousBuild()).thenReturn(buildWithNoActions);
+
+        var step = new RepositoryMinerStep();
+        var result = step.previousBuildStatistics(SCM_KEY, currentRun);
+
+        assertThat(result).hasFiles(EXISTING_FILE);
+    }
+
+    @Test
+    @Issue("JENKINS-74804")
+    void shouldReturnEmptyStatisticsWhenScmKeyDoesNotMatchAnyAction() {
+        var statistics = new RepositoryStatistics();
+        statistics.add(new FileStatisticsBuilder().build(EXISTING_FILE));
+
+        ForensicsBuildAction action = createAction(SCM_KEY, statistics);
+
+        var previousBuild = mock(Run.class);
+        when(previousBuild.getActions(ForensicsBuildAction.class))
+                .thenReturn(List.of(action));
+
+        var currentRun = mock(Run.class);
+        when(currentRun.getPreviousBuild()).thenReturn(previousBuild);
+
+        var step = new RepositoryMinerStep();
+        var result = step.previousBuildStatistics("svn://different-repo", currentRun);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldGetAndSetScm() {
+        var step = new RepositoryMinerStep();
+
+        assertThat(step.getScm()).isEmpty();
+
+        step.setScm("git");
+        assertThat(step.getScm()).isEqualTo("git");
+    }
+
+    private ForensicsBuildAction createAction(final String scmKey, final RepositoryStatistics statistics) {
+        ForensicsBuildAction action = mock(ForensicsBuildAction.class);
+        when(action.getScmKey()).thenReturn(scmKey);
+        when(action.getResult()).thenReturn(statistics);
+        return action;
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix `RepositoryMinerStep`: match previous-build statistics by exact SCM key

`previousBuildStatistics()` looked up prior results using a substring
match (`contains`) against the configured `scm` field instead of the
actual repository's key. This could resolve the wrong repository's
statistics when multiple SCMs are mined, or fail to match at all.

- Match by the full SCM key using `equals` instead of `contains`.
- Look up previous statistics using `repository.getKey()` rather than
  the raw `scm` configuration value.
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
